### PR TITLE
feat: Creates vault config.hcl file

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,12 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+options:
+  default_lease_ttl:
+    type: string
+    default: "168h"
+    description: Specifies the default lease duration for Vault's tokens and secrets.
+  max_lease_ttl:
+    type: string
+    default: "720h"
+    description: Specifies the maximum possible lease duration for Vault's tokens and secrets.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 name: vault
@@ -24,11 +24,9 @@ assumes:
 storage:
   vault-raft:
     type: filesystem
-    minimum-size: 10G
     location: /var/snap/vault/common/raft
   config:
     type: filesystem
-    minimum-size: 5M
     location: /var/snap/vault/common/config
 
 peers:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -20,3 +20,17 @@ issues: https://github.com/canonical/vault-operator/issues
 
 assumes:
   - juju >= 3.1
+
+storage:
+  vault-raft:
+    type: filesystem
+    minimum-size: 10G
+    location: /var/snap/vault/common/raft
+  config:
+    type: filesystem
+    minimum-size: 5M
+    location: /var/snap/vault/common/config
+
+peers:
+  vault-peers:
+    interface: vault-peer

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
+jinja2
 ops
+pyhcl

--- a/src/charm.py
+++ b/src/charm.py
@@ -7,7 +7,6 @@
 
 import logging
 import os
-from pathlib import Path
 from typing import Optional
 
 import hcl  # type: ignore[import-untyped]
@@ -59,43 +58,40 @@ def render_vault_config_file(
 class UnitFileDirectory:
     """A class to interact with a unit file directory."""
 
-    def exists(self, file_path: str) -> bool:
+    def exists(self, path: str) -> bool:
         """Check if a file exists.
 
         Args:
-            file_path: The path of the file
+            path: The path of the file
 
         Returns:
             bool: Whether the file exists
         """
-        return os.path.isfile(file_path)
+        return os.path.isfile(path)
 
-    def pull(self, file_path: str) -> str:
+    def pull(self, path: str) -> str:
         """Get the content of a file.
 
         Args:
-            file_path: The path of the file
+            path: The path of the file
 
         Returns:
             str: The content of the file
         """
-        with open(file_path, "r") as read_file:
+        with open(path, "r") as read_file:
             content = read_file.read()
         return content
 
-    def push(self, parent_dir: str, file_name: str, content: str) -> None:
+    def push(self, path: str, source: str) -> None:
         """Pushes a file to the unit.
 
         Args:
-            parent_dir: The parent directory of the file to be pushed
-            file_name: The name of the file to be pushed
-            content: The contents of the file to be pushed
+            path: The path of the file
+            source: The contents of the file to be pushed
         """
-        Path(parent_dir).mkdir(parents=True, exist_ok=True)
-        file_name = f"{parent_dir}/{file_name}"
-        with open(file_name, "w") as write_file:
-            write_file.write(content)
-        logger.info("Pushed file %s", file_name)
+        with open(path, "w") as write_file:
+            write_file.write(source)
+        logger.info("Pushed file %s", path)
 
 
 def config_file_content_matches(existing_content: str, new_content: str) -> bool:
@@ -188,14 +184,13 @@ class VaultOperatorCharm(CharmBase):
         existing_content = ""
         unit_file_directory = UnitFileDirectory()
         vault_config_file_path = f"{VAULT_CONFIG_PATH}/{VAULT_CONFIG_FILE_NAME}"
-        if unit_file_directory.exists(file_path=vault_config_file_path):
-            existing_content = unit_file_directory.pull(file_path=vault_config_file_path)
+        if unit_file_directory.exists(path=vault_config_file_path):
+            existing_content = unit_file_directory.pull(path=vault_config_file_path)
 
         if not config_file_content_matches(existing_content=existing_content, new_content=content):
             unit_file_directory.push(
-                parent_dir=VAULT_CONFIG_PATH,
-                file_name=VAULT_CONFIG_FILE_NAME,
-                content=content,
+                path=vault_config_file_path,
+                source=content,
             )
 
     @property

--- a/src/charm.py
+++ b/src/charm.py
@@ -56,7 +56,12 @@ def render_vault_config_file(
 
 
 class UnitFileDirectory:
-    """A class to interact with a unit file directory."""
+    """A class to interact with a unit file directory.
+
+    This class has the same method signatures as Pebble API in the Ops
+    Library. This is to improve consistency between the Machine and Kubernetes
+    versions of the charm.
+    """
 
     def exists(self, path: str) -> bool:
         """Check if a file exists.
@@ -136,6 +141,7 @@ class VaultOperatorCharm(CharmBase):
 
     def __init__(self, *args):
         super().__init__(*args)
+        self.unit_file_directory = UnitFileDirectory()
         self.framework.observe(self.on.install, self._configure)
         self.framework.observe(self.on.update_status, self._configure)
         self.framework.observe(self.on.config_changed, self._configure)
@@ -182,13 +188,12 @@ class VaultOperatorCharm(CharmBase):
             node_id=self._node_id,
         )
         existing_content = ""
-        unit_file_directory = UnitFileDirectory()
         vault_config_file_path = f"{VAULT_CONFIG_PATH}/{VAULT_CONFIG_FILE_NAME}"
-        if unit_file_directory.exists(path=vault_config_file_path):
-            existing_content = unit_file_directory.pull(path=vault_config_file_path)
+        if self.unit_file_directory.exists(path=vault_config_file_path):
+            existing_content = self.unit_file_directory.pull(path=vault_config_file_path)
 
         if not config_file_content_matches(existing_content=existing_content, new_content=content):
-            unit_file_directory.push(
+            self.unit_file_directory.push(
                 path=vault_config_file_path,
                 source=content,
             )

--- a/src/charm.py
+++ b/src/charm.py
@@ -140,7 +140,7 @@ class VaultOperatorCharm(CharmBase):
 
     def __init__(self, *args):
         super().__init__(*args)
-        self.unit_file_directory = Machine()
+        self.machine = Machine()
         self.framework.observe(self.on.install, self._configure)
         self.framework.observe(self.on.update_status, self._configure)
         self.framework.observe(self.on.config_changed, self._configure)
@@ -193,11 +193,11 @@ class VaultOperatorCharm(CharmBase):
         )
         existing_content = ""
         vault_config_file_path = f"{VAULT_CONFIG_PATH}/{VAULT_CONFIG_FILE_NAME}"
-        if self.unit_file_directory.exists(path=vault_config_file_path):
-            existing_content = self.unit_file_directory.pull(path=vault_config_file_path)
+        if self.machine.exists(path=vault_config_file_path):
+            existing_content = self.machine.pull(path=vault_config_file_path)
 
         if not config_file_content_matches(existing_content=existing_content, new_content=content):
-            self.unit_file_directory.push(
+            self.machine.push(
                 path=vault_config_file_path,
                 source=content,
             )

--- a/src/charm.py
+++ b/src/charm.py
@@ -6,17 +6,132 @@
 """A machine charm for Vault."""
 
 import logging
+import os
+from pathlib import Path
+from typing import Optional
 
+import hcl  # type: ignore[import-untyped]
 from charms.operator_libs_linux.v1 import snap
-from ops.charm import CharmBase, InstallEvent
+from jinja2 import Environment, FileSystemLoader
+from ops.charm import CharmBase
 from ops.main import main
-from ops.model import ActiveStatus, MaintenanceStatus
+from ops.model import ActiveStatus, MaintenanceStatus, ModelError, WaitingStatus
 
 logger = logging.getLogger(__name__)
 
+CONFIG_TEMPLATE_DIR_PATH = "src/templates/"
+CONFIG_TEMPLATE_NAME = "vault.hcl.j2"
+PEER_RELATION_NAME = "vault-peers"
+VAULT_CONFIG_PATH = "/var/snap/vault/common/config"
+VAULT_CONFIG_FILE_NAME = "vault.hcl"
+VAULT_PORT = 8200
+VAULT_CLUSTER_PORT = 8201
 VAULT_SNAP_NAME = "vault"
 VAULT_SNAP_CHANNEL = "1.12/stable"
 VAULT_SNAP_REVISION = 2166
+VAULT_STORAGE_PATH = "/var/snap/vault/common/raft"
+
+
+def render_vault_config_file(
+    default_lease_ttl: str,
+    max_lease_ttl: str,
+    cluster_address: str,
+    api_address: str,
+    tcp_address: str,
+    raft_storage_path: str,
+    node_id: str,
+) -> str:
+    """Render the Vault config file."""
+    jinja2_environment = Environment(loader=FileSystemLoader(CONFIG_TEMPLATE_DIR_PATH))
+    template = jinja2_environment.get_template(CONFIG_TEMPLATE_NAME)
+    content = template.render(
+        default_lease_ttl=default_lease_ttl,
+        max_lease_ttl=max_lease_ttl,
+        cluster_address=cluster_address,
+        api_address=api_address,
+        tcp_address=tcp_address,
+        raft_storage_path=raft_storage_path,
+        node_id=node_id,
+    )
+    return content
+
+
+class UnitFileDirectory:
+    """A class to interact with a unit file directory."""
+
+    def exists(self, file_path: str) -> bool:
+        """Check if a file exists.
+
+        Args:
+            file_path: The path of the file
+
+        Returns:
+            bool: Whether the file exists
+        """
+        return os.path.isfile(file_path)
+
+    def pull(self, file_path: str) -> str:
+        """Get the content of a file.
+
+        Args:
+            file_path: The path of the file
+
+        Returns:
+            str: The content of the file
+        """
+        with open(file_path, "r") as read_file:
+            content = read_file.read()
+        return content
+
+    def push(self, parent_dir: str, file_name: str, content: str) -> None:
+        """Pushes a file to the unit.
+
+        Args:
+            parent_dir: The parent directory of the file to be pushed
+            file_name: The name of the file to be pushed
+            content: The contents of the file to be pushed
+        """
+        Path(parent_dir).mkdir(parents=True, exist_ok=True)
+        file_name = f"{parent_dir}/{file_name}"
+        with open(file_name, "w") as write_file:
+            write_file.write(content)
+
+
+def config_file_content_matches(existing_content: str, new_content: str) -> bool:
+    """Return whether two Vault config file contents match.
+
+    We check if the retry_join addresses match, and then we check if the rest of the config
+    file matches.
+
+    Returns:
+        bool: Whether the vault config file content matches
+    """
+    existing_config_hcl = hcl.loads(existing_content)
+    new_content_hcl = hcl.loads(new_content)
+    if not existing_config_hcl:
+        logger.info("Existing config file is empty")
+        return existing_config_hcl == new_content_hcl
+    if not new_content_hcl:
+        logger.info("New config file is empty")
+        return existing_config_hcl == new_content_hcl
+
+    new_retry_joins = new_content_hcl["storage"]["raft"].pop("retry_join", [])
+    existing_retry_joins = existing_config_hcl["storage"]["raft"].pop("retry_join", [])
+
+    # If there is only one retry join, it is a dict
+    if isinstance(new_retry_joins, dict):
+        new_retry_joins = [new_retry_joins]
+    if isinstance(existing_retry_joins, dict):
+        existing_retry_joins = [existing_retry_joins]
+
+    new_retry_join_api_addresses = {address["leader_api_addr"] for address in new_retry_joins}
+    existing_retry_join_api_addresses = {
+        address["leader_api_addr"] for address in existing_retry_joins
+    }
+    return (
+        new_retry_join_api_addresses == existing_retry_join_api_addresses
+        and new_content_hcl == existing_config_hcl
+    )
 
 
 class VaultOperatorCharm(CharmBase):
@@ -26,11 +141,16 @@ class VaultOperatorCharm(CharmBase):
         super().__init__(*args)
         self.framework.observe(self.on.install, self._configure)
         self.framework.observe(self.on.update_status, self._configure)
+        self.framework.observe(self.on.config_changed, self._configure)
 
-    def _configure(self, event: InstallEvent):
+    def _configure(self, _):
         """Handle Vault installation."""
+        if not self._bind_address:
+            self.unit.status = WaitingStatus("Waiting for bind address")
+            return
         self.unit.status = MaintenanceStatus("Installing Vault")
         self._install_vault_snap()
+        self._generate_vault_config_file()
         self.unit.status = ActiveStatus()
 
     def _install_vault_snap(self) -> None:
@@ -46,6 +166,82 @@ class VaultOperatorCharm(CharmBase):
         except snap.SnapError as e:
             logger.error("An exception occurred when installing Vault. Reason: %s", str(e))
             raise
+
+    def _generate_vault_config_file(self) -> None:
+        """Handle the creation of the Vault config file."""
+        if not self._cluster_address:
+            logger.warning("Cluster address not found")
+            return
+        if not self._api_address:
+            logger.warning("API address not found")
+            return
+        content = render_vault_config_file(
+            default_lease_ttl=self.model.config["default_lease_ttl"],
+            max_lease_ttl=self.model.config["max_lease_ttl"],
+            cluster_address=self._cluster_address,
+            api_address=self._api_address,
+            tcp_address=f"[::]:{VAULT_PORT}",
+            raft_storage_path=VAULT_STORAGE_PATH,
+            node_id=self._node_id,
+        )
+        existing_content = ""
+        unit_file_directory = UnitFileDirectory()
+        vault_config_file_path = f"{VAULT_CONFIG_PATH}/{VAULT_CONFIG_FILE_NAME}"
+        if unit_file_directory.exists(file_path=vault_config_file_path):
+            existing_content = unit_file_directory.pull(file_path=vault_config_file_path)
+
+        if not config_file_content_matches(existing_content=existing_content, new_content=content):
+            unit_file_directory.push(
+                parent_dir=VAULT_CONFIG_PATH,
+                file_name=VAULT_CONFIG_FILE_NAME,
+                content=content,
+            )
+
+    @property
+    def _bind_address(self) -> Optional[str]:
+        """Fetches bind address from peer relation and returns it.
+
+        Returns:
+            str: Bind address
+        """
+        peer_relation = self.model.get_relation(PEER_RELATION_NAME)
+        if not peer_relation:
+            return None
+        try:
+            binding = self.model.get_binding(peer_relation)
+            if not binding or not binding.network.bind_address:
+                return None
+            return str(binding.network.bind_address)
+        except ModelError:
+            return None
+
+    @property
+    def _api_address(self) -> Optional[str]:
+        """Returns the FQDN with the https schema and vault port.
+
+        Example: "https://1.2.3.4:8200"
+        """
+        if not self._bind_address:
+            return None
+        return f"https://{self._bind_address}:{VAULT_PORT}"
+
+    @property
+    def _cluster_address(self) -> Optional[str]:
+        """Return the FQDN with the https schema and vault port.
+
+        Example: "https://1.2.3.4:8201"
+        """
+        if not self._bind_address:
+            return None
+        return f"https://{self._bind_address}:{VAULT_CLUSTER_PORT}"
+
+    @property
+    def _node_id(self) -> str:
+        """Return node id for vault.
+
+        Example of node id: "vault-k8s-0"
+        """
+        return f"{self.model.name}-{self.unit.name}"
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/src/charm.py
+++ b/src/charm.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 
@@ -95,6 +95,7 @@ class UnitFileDirectory:
         file_name = f"{parent_dir}/{file_name}"
         with open(file_name, "w") as write_file:
             write_file.write(content)
+        logger.info("Pushed file %s", file_name)
 
 
 def config_file_content_matches(existing_content: str, new_content: str) -> bool:

--- a/src/templates/vault.hcl.j2
+++ b/src/templates/vault.hcl.j2
@@ -1,0 +1,20 @@
+ui      = true
+storage "raft" {
+  path= "{{ raft_storage_path }}"
+  node_id = "{{ node_id }}"
+  }
+listener "tcp" {
+  telemetry {
+    unauthenticated_metrics_access = true
+  }
+  address       = "{{ tcp_address }}"
+}
+default_lease_ttl = "{{ default_lease_ttl }}"
+max_lease_ttl     = "{{ max_lease_ttl }}"
+disable_mlock     = true
+cluster_addr      = "{{ cluster_address }}"
+api_addr          = "{{ api_address }}"
+telemetry {
+  disable_hostname = true
+  prometheus_retention_time = "12h"
+}

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,6 +2,7 @@ black
 codespell
 coverage[toml]
 ops
+pyhcl
 pyright
 pytest
 ruff

--- a/tests/unit/config.hcl
+++ b/tests/unit/config.hcl
@@ -1,0 +1,20 @@
+ui      = true
+storage "raft" {
+  path= "/var/snap/vault/common/raft"
+  node_id = "whatever-vault/0"
+  }
+listener "tcp" {
+  telemetry {
+    unauthenticated_metrics_access = true
+  }
+  address       = "[::]:8200"
+}
+default_lease_ttl = "168h"
+max_lease_ttl     = "720h"
+disable_mlock     = true
+cluster_addr      = "https://1.2.1.2:8201"
+api_addr          = "https://1.2.1.2:8200"
+telemetry {
+  disable_hostname = true
+  prometheus_retention_time = "12h"
+}

--- a/tests/unit/config_with_raft_peers.hcl
+++ b/tests/unit/config_with_raft_peers.hcl
@@ -1,0 +1,31 @@
+ui      = true
+storage "raft" {
+  path= "/vault/raft"
+  node_id = "whatever-vault-k8s/0"
+   retry_join {
+    leader_api_addr = "http://127.0.0.1:8200"
+    leader_ca_cert_file = "/path/to/ca1"
+  }
+  retry_join {
+    leader_api_addr = "http://127.0.0.2:8200"
+    leader_ca_cert_file = "/path/to/ca1"
+  }
+
+  }
+listener "tcp" {
+  telemetry {
+    unauthenticated_metrics_access = true
+  }
+  address       = "[::]:8200"
+  tls_cert_file = "/vault/certs/cert.pem"
+  tls_key_file  = "/vault/certs/key.pem"
+}
+default_lease_ttl = "168h"
+max_lease_ttl     = "720h"
+disable_mlock     = true
+cluster_addr      = "https://1.2.3.4:8201"
+api_addr          = "https://1.2.3.4:8200"
+telemetry {
+  disable_hostname = true
+  prometheus_retention_time = "12h"
+}

--- a/tests/unit/config_with_raft_peers_equivalent.hcl
+++ b/tests/unit/config_with_raft_peers_equivalent.hcl
@@ -1,0 +1,32 @@
+ui      = true
+storage "raft" {
+  path= "/vault/raft"
+  node_id = "whatever-vault-k8s/0"
+  # The order is different from in "config_with_raft_peers.hcl"
+  retry_join {
+    leader_api_addr = "http://127.0.0.2:8200"
+    leader_ca_cert_file = "/path/to/ca1"
+  }
+   retry_join {
+    leader_api_addr = "http://127.0.0.1:8200"
+    leader_ca_cert_file = "/path/to/ca1"
+  }
+
+  }
+listener "tcp" {
+  telemetry {
+    unauthenticated_metrics_access = true
+  }
+  address       = "[::]:8200"
+  tls_cert_file = "/vault/certs/cert.pem"
+  tls_key_file  = "/vault/certs/key.pem"
+}
+default_lease_ttl = "168h"
+max_lease_ttl     = "720h"
+disable_mlock     = true
+cluster_addr      = "https://1.2.3.4:8201"
+api_addr          = "https://1.2.3.4:8200"
+telemetry {
+  disable_hostname = true
+  prometheus_retention_time = "12h"
+}

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 import unittest

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -37,13 +37,13 @@ class MockBinding:
 
 
 class MockUnitFileDirectory:
-    def exists(self, file_path: str) -> bool:
+    def exists(self, path: str) -> bool:
         pass
 
-    def push(self, parent_dir: str, file_name: str, content: str) -> None:
+    def push(self, path: str, source: str) -> None:
         pass
 
-    def pull(self, file_path: str) -> str:
+    def pull(self, path: str) -> str:
         pass
 
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -48,7 +48,9 @@ class MockUnitFileDirectory:
 
 
 class TestCharm(unittest.TestCase):
-    def setUp(self):
+    @patch("charm.UnitFileDirectory")
+    def setUp(self, patch_unit_file_directory):
+        patch_unit_file_directory.return_value = MockUnitFileDirectory()
         self.app_name = "vault-k8s"
         self.harness = ops.testing.Harness(VaultOperatorCharm)
         self.addCleanup(self.harness.cleanup)
@@ -58,11 +60,10 @@ class TestCharm(unittest.TestCase):
         """Set the peer relation and return the relation id."""
         return self.harness.add_relation(relation_name="vault-peers", remote_app=self.app_name)
 
-    @patch("charm.UnitFileDirectory")
     @patch("ops.model.Model.get_binding")
     @patch("charms.operator_libs_linux.v1.snap.SnapCache")
     def test_given_vault_snap_uninstalled_when_configure_then_vault_snap_installed(
-        self, mock_snap_cache, patch_get_binding, patch_unit_file_directory
+        self, mock_snap_cache, patch_get_binding
     ):
         vault_snap = MockSnapObject("vault")
         snap_cache = {"vault": vault_snap}
@@ -71,7 +72,6 @@ class TestCharm(unittest.TestCase):
         patch_get_binding.return_value = MockBinding(
             bind_address="1.2.1.2", ingress_address="10.1.0.1"
         )
-        patch_unit_file_directory.return_value = MockUnitFileDirectory()
 
         self.harness.charm.on.install.emit()
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -4,9 +4,10 @@
 import unittest
 from unittest.mock import patch
 
+import hcl
 import ops
 import ops.testing
-from charm import VaultOperatorCharm
+from charm import VaultOperatorCharm, config_file_content_matches
 from charms.operator_libs_linux.v1.snap import SnapState
 
 
@@ -26,33 +27,87 @@ class MockSnapObject:
 
 
 class MockNetwork:
-    def __init__(self, bind_address: str, ingress_address: str):
+    def __init__(self, bind_address: str):
         self.bind_address = bind_address
-        self.ingress_address = ingress_address
 
 
 class MockBinding:
-    def __init__(self, bind_address: str, ingress_address: str):
-        self.network = MockNetwork(bind_address=bind_address, ingress_address=ingress_address)
+    def __init__(self, bind_address: str):
+        self.network = MockNetwork(bind_address=bind_address)
 
 
-class MockUnitFileDirectory:
+class MockMachine:
+    def __init__(self, exists_return_value: bool = False):
+        self.exists_return_value = exists_return_value
+        self.push_called = False
+
     def exists(self, path: str) -> bool:
+        return self.exists_return_value
         pass
 
     def push(self, path: str, source: str) -> None:
-        pass
+        self.push_called = True
+        self.push_called_with = {"path": path, "source": source}
 
     def pull(self, path: str) -> str:
         pass
 
 
+def read_file(path: str) -> str:
+    """Read a file and returns as a string.
+
+    Args:
+        path (str): path to the file.
+
+    Returns:
+        str: content of the file.
+    """
+    with open(path, "r") as f:
+        content = f.read()
+    return content
+
+
+class TestConfigFileContentMatches(unittest.TestCase):
+    def test_given_identical_vault_config_when_config_file_content_matches_returns_true(self):
+        existing_content = read_file("tests/unit/config.hcl")
+        new_content = read_file("tests/unit/config.hcl")
+
+        matches = config_file_content_matches(
+            existing_content=existing_content, new_content=new_content
+        )
+
+        self.assertTrue(matches)
+
+    def test_given_different_vault_config_when_config_file_content_matches_returns_false(self):
+        existing_content = read_file("tests/unit/config.hcl")
+        new_content = read_file("tests/unit/config_with_raft_peers.hcl")
+
+        matches = config_file_content_matches(
+            existing_content=existing_content, new_content=new_content
+        )
+
+        self.assertFalse(matches)
+
+    def test_given_equivalent_vault_config_when_config_file_content_matches_returns_true(self):
+        existing_content = read_file("tests/unit/config_with_raft_peers.hcl")
+        new_content = read_file("tests/unit/config_with_raft_peers_equivalent.hcl")
+
+        matches = config_file_content_matches(
+            existing_content=existing_content, new_content=new_content
+        )
+
+        self.assertTrue(matches)
+
+
 class TestCharm(unittest.TestCase):
-    @patch("charm.UnitFileDirectory")
-    def setUp(self, patch_unit_file_directory):
-        patch_unit_file_directory.return_value = MockUnitFileDirectory()
+    @patch("charm.Machine")
+    def setUp(self, patch_machine):
+        self.mock_machine = MockMachine()
+        self.model_name = "whatever"
+        patch_machine.return_value = self.mock_machine
         self.app_name = "vault-k8s"
         self.harness = ops.testing.Harness(VaultOperatorCharm)
+        self.harness.set_model_name(self.model_name)
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
 
@@ -69,14 +124,29 @@ class TestCharm(unittest.TestCase):
         snap_cache = {"vault": vault_snap}
         mock_snap_cache.return_value = snap_cache
         self._set_peer_relation()
-        patch_get_binding.return_value = MockBinding(
-            bind_address="1.2.1.2", ingress_address="10.1.0.1"
-        )
+        patch_get_binding.return_value = MockBinding(bind_address="1.2.1.2")
 
         self.harness.charm.on.install.emit()
 
         mock_snap_cache.assert_called_once_with()
-
         assert vault_snap.ensure_called
         assert vault_snap.ensure_called_with == (SnapState.Latest, "1.12/stable", 2166)
         assert vault_snap.hold_called
+
+    @patch("ops.model.Model.get_binding")
+    @patch("charms.operator_libs_linux.v1.snap.SnapCache")
+    def test_given_config_file_not_exists_when_configure_then_config_file_pushed(
+        self, _, patch_get_binding
+    ):
+        expected_content_hcl = hcl.loads(read_file("tests/unit/config.hcl"))
+        patch_get_binding.return_value = MockBinding(bind_address="1.2.1.2")
+        self._set_peer_relation()
+
+        self.harness.charm.on.install.emit()
+
+        assert self.mock_machine.push_called
+        assert (
+            self.mock_machine.push_called_with["path"] == "/var/snap/vault/common/config/vault.hcl"
+        )
+        pushed_content_hcl = hcl.loads(self.mock_machine.push_called_with["source"])
+        self.assertEqual(pushed_content_hcl, expected_content_hcl)


### PR DESCRIPTION
# Description

This PR includes the what is needed to create a barebone vault configuration file needed to run the Vault server. The file is being placed in the `/var/snap/vault/common/` directory where the snap can have access to it.

## Note

The current version of the config file does not yet contain TLS Certificates and the complete Raft configuration. This was intentional in order to make this PR smaller.  Those will come in follow-up PR's.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
