### PR TITLE
chore: Add publishing workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,3 +16,14 @@ jobs:
 
   unit-tests-with-coverage:
     uses: ./.github/workflows/unit-test.yaml
+
+  publish-charm:
+    needs:
+      - lint-report
+      - static-analysis
+      - unit-tests-with-coverage
+    if: ${{ github.ref_name == 'main' }}
+    uses: ./.github/workflows/publish-charm.yaml
+    with:
+      charm-file-name: "vault-dev_ubuntu-22.04-amd64.charm"
+    secrets: inherit

--- a/.github/workflows/publish-charm.yaml
+++ b/.github/workflows/publish-charm.yaml
@@ -1,0 +1,42 @@
+name: Publish charm
+
+on:
+  workflow_call:
+    inputs:
+      charm-file-name:
+        description: Charm file name
+        required: true
+        type: string
+    secrets:
+      CHARMCRAFT_AUTH:
+        required: true
+
+jobs:
+  publish-charm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          fetch-depth: 0
+      - name: Install charmcraft
+        run: sudo snap install charmcraft --classic
+      - name: Fetch Tested Charm
+        uses: actions/download-artifact@v4
+        with:
+          name: tested-charm
+      - name: Move charm in current directory
+        run: find ./ -name ${{ inputs.charm-file-name }} -exec mv -t ./ {} \;
+      - name: Upload charm to Charmhub
+        uses: canonical/charming-actions/upload-charm@2.4.0
+        with:
+          built-charm-path: ${{ inputs.charm-file-name }}
+          credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          channel: latest/edge
+      - name: Archive charmcraft logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: charmcraft-logs
+          path: /home/runner/.local/state/charmcraft/log/*.log

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,7 +1,7 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-name: vault
+name: vault-dev
 
 display-name: Vault Operator
 summary: A tool for managing secrets
@@ -14,7 +14,7 @@ description: |
   network encryption-as-a-service, or generate AWS IAM/STS
   credentials, SQL/NoSQL databases, X.509 certificates,
   SSH credentials, and more.
-website: https://charmhub.io/vault
+website: https://charmhub.io/vault-dev
 source: https://github.com/canonical/vault-operator
 issues: https://github.com/canonical/vault-operator/issues
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -17,6 +17,7 @@ description: |
 website: https://charmhub.io/vault-dev
 source: https://github.com/canonical/vault-operator
 issues: https://github.com/canonical/vault-operator/issues
+docs: https://discourse.charmhub.io/t/vault-operator-machine/12983
 
 assumes:
   - juju >= 3.1

--- a/tests/unit/config.hcl
+++ b/tests/unit/config.hcl
@@ -1,7 +1,7 @@
 ui      = true
 storage "raft" {
   path= "/var/snap/vault/common/raft"
-  node_id = "whatever-vault/0"
+  node_id = "whatever-vault-dev/0"
   }
 listener "tcp" {
   telemetry {


### PR DESCRIPTION
# Description

Until this charm is published to the [official Vault Charm on Charmhub](https://charmhub.io/vault) and that we have a 1.15 track for it, we still want to publish it somewhere, for development, documentation and workflow standardisation purposes.

I created a new `vault-dev` charm on charmhub to serve this purpose as well as a the necessary CI workflows to publish the charm there.

As soon as we have the new track created and alignement with the Openstack team, we shall point to the appropriate charm on Charmhub.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
