### PR TITLE
fix: Build charm before publishing it

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,8 +22,6 @@ jobs:
       - lint-report
       - static-analysis
       - unit-tests-with-coverage
-    if: ${{ github.ref_name == 'main' }}
+    # if: ${{ github.ref_name == 'main' }}
     uses: ./.github/workflows/publish-charm.yaml
-    with:
-      charm-file-name: "vault-dev_ubuntu-22.04-amd64.charm"
     secrets: inherit

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,6 +22,6 @@ jobs:
       - lint-report
       - static-analysis
       - unit-tests-with-coverage
-    # if: ${{ github.ref_name == 'main' }}
+    if: ${{ github.ref_name == 'main' }}
     uses: ./.github/workflows/publish-charm.yaml
     secrets: inherit

--- a/.github/workflows/publish-charm.yaml
+++ b/.github/workflows/publish-charm.yaml
@@ -2,11 +2,6 @@ name: Publish charm
 
 on:
   workflow_call:
-    inputs:
-      charm-file-name:
-        description: Charm file name
-        required: true
-        type: string
     secrets:
       CHARMCRAFT_AUTH:
         required: true
@@ -16,21 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-        with:
-          fetch-depth: 0
-      - name: Install charmcraft
-        run: sudo snap install charmcraft --classic
-      - name: Fetch Tested Charm
-        uses: actions/download-artifact@v4
-        with:
-          name: tested-charm
-      - name: Move charm in current directory
-        run: find ./ -name ${{ inputs.charm-file-name }} -exec mv -t ./ {} \;
+        uses: actions/checkout@v4
       - name: Upload charm to Charmhub
         uses: canonical/charming-actions/upload-charm@2.4.0
         with:
-          built-charm-path: ${{ inputs.charm-file-name }}
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: latest/edge


### PR DESCRIPTION
# Description

The was an issue with PR #13 where we would assume the charm had been built before but actually wasn't. Here we have the  `canonical/charming-actions/upload-charm` workflow build the charm.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
