### PR TITLE
feat: Start vaultd service

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -3,7 +3,7 @@
 
 name: vault-dev
 
-display-name: Vault Operator
+display-name: Vault
 summary: A tool for managing secrets
 description: |
   Vault secures, stores, and tightly controls access to

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -23,12 +23,9 @@ assumes:
   - juju >= 3.1
 
 storage:
-  vault-raft:
+  vault:
     type: filesystem
-    location: /var/snap/vault/common/raft
-  config:
-    type: filesystem
-    location: /var/snap/vault/common/config
+    location: /var/snap/vault/common
 
 peers:
   vault-peers:

--- a/src/charm.py
+++ b/src/charm.py
@@ -109,7 +109,7 @@ class VaultOperatorCharm(CharmBase):
             self,
             scrape_configs=[
                 {
-                    "scheme": "https",
+                    "scheme": "http",
                     "tls_config": {"insecure_skip_verify": True},
                     "metrics_path": "/v1/sys/metrics",
                     "static_configs": [{"targets": [f"*:{VAULT_PORT}"]}],
@@ -254,23 +254,23 @@ class VaultOperatorCharm(CharmBase):
 
     @property
     def _api_address(self) -> Optional[str]:
-        """Returns the IP with the https schema and vault port.
+        """Returns the IP with the http schema and vault port.
 
-        Example: "https://1.2.3.4:8200"
+        Example: "http://1.2.3.4:8200"
         """
         if not self._bind_address:
             return None
-        return f"https://{self._bind_address}:{VAULT_PORT}"
+        return f"http://{self._bind_address}:{VAULT_PORT}"
 
     @property
     def _cluster_address(self) -> Optional[str]:
-        """Return the IP with the https schema and vault port.
+        """Return the IP with the http schema and vault port.
 
-        Example: "https://1.2.3.4:8201"
+        Example: "http://1.2.3.4:8201"
         """
         if not self._bind_address:
             return None
-        return f"https://{self._bind_address}:{VAULT_CLUSTER_PORT}"
+        return f"http://{self._bind_address}:{VAULT_CLUSTER_PORT}"
 
     @property
     def _node_id(self) -> str:

--- a/src/machine.py
+++ b/src/machine.py
@@ -7,6 +7,7 @@
 
 import logging
 import os
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -52,3 +53,7 @@ class Machine:
         with open(path, "w") as write_file:
             write_file.write(source)
             logger.info("Pushed file %s", path)
+
+    def make_dir(self, path: str) -> None:
+        """Create a directory."""
+        Path(path).mkdir(parents=True, exist_ok=True)

--- a/src/templates/vault.hcl.j2
+++ b/src/templates/vault.hcl.j2
@@ -13,6 +13,7 @@ listener "tcp" {
     unauthenticated_metrics_access = true
   }
   address       = "{{ tcp_address }}"
+  tls_disable = 1
 }
 default_lease_ttl = "{{ default_lease_ttl }}"
 max_lease_ttl     = "{{ max_lease_ttl }}"

--- a/tests/unit/config.hcl
+++ b/tests/unit/config.hcl
@@ -8,6 +8,7 @@ listener "tcp" {
     unauthenticated_metrics_access = true
   }
   address       = "[::]:8200"
+  tls_disable = 1
 }
 default_lease_ttl = "168h"
 max_lease_ttl     = "720h"

--- a/tests/unit/config.hcl
+++ b/tests/unit/config.hcl
@@ -13,8 +13,8 @@ listener "tcp" {
 default_lease_ttl = "168h"
 max_lease_ttl     = "720h"
 disable_mlock     = true
-cluster_addr      = "https://1.2.1.2:8201"
-api_addr          = "https://1.2.1.2:8200"
+cluster_addr      = "http://1.2.1.2:8201"
+api_addr          = "http://1.2.1.2:8200"
 telemetry {
   disable_hostname = true
   prometheus_retention_time = "12h"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -59,6 +59,9 @@ class MockMachine:
     def pull(self, path: str) -> str:
         pass
 
+    def make_dir(self, path: str) -> None:
+        pass
+
 
 def read_file(path: str) -> str:
     """Read a file and returns as a string.
@@ -164,9 +167,7 @@ class TestCharm(unittest.TestCase):
         self.harness.charm.on.install.emit()
 
         assert self.mock_machine.push_called
-        assert (
-            self.mock_machine.push_called_with["path"] == "/var/snap/vault/common/config/vault.hcl"
-        )
+        assert self.mock_machine.push_called_with["path"] == "/var/snap/vault/common/vault.hcl"
         pushed_content_hcl = hcl.loads(self.mock_machine.push_called_with["source"])
         self.assertEqual(pushed_content_hcl, expected_content_hcl)
 


### PR DESCRIPTION
# Description

Now that the Vault snap supports the vaultd daemon service, we start this service as part of the deployment of the Vault charm.

## Note
We have to use the `latest/edge` track of the snap for the moment as it is the only one that contains the daemon. As we move it to its own track and promote it, we should eventually switch from `latest/edge` to `1.15/stable`.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
