### PR TITLE
chore: Fix ruff warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,9 +16,10 @@ target-version = ["py38"]
 
 # Linting tools configuration
 [tool.ruff]
+extend-exclude = ["__pycache__", "*.egg_info"]
 line-length = 99
-select = ["E", "W", "F", "C", "N", "D", "I001"]
-extend-ignore = [
+lint.select = ["E", "W", "F", "C", "N", "D", "I001"]
+lint.extend-ignore = [
     "D203",
     "D204",
     "D213",
@@ -31,12 +32,9 @@ extend-ignore = [
     "D409",
     "D413",
 ]
-ignore = ["E501", "D107"]
-extend-exclude = ["__pycache__", "*.egg_info"]
-per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
-
-[tool.ruff.mccabe]
-max-complexity = 10
+lint.ignore = ["E501", "D107"]
+lint.mccabe.max-complexity = 10
+lint.per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
 
 [tool.codespell]
 skip = "build,lib,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.coverage"


### PR DESCRIPTION
This removes some warnings about deprecated config keys.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
