### PR TITLE
fix: Don't display installing vault when we're not

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -138,7 +138,6 @@ class VaultOperatorCharm(CharmBase):
         if not self.unit.is_leader() and len(self._other_peer_node_api_addresses()) == 0:
             self.unit.status = WaitingStatus("Waiting for other units to provide their addresses")
             return
-        self.unit.status = MaintenanceStatus("Installing Vault")
         self._install_vault_snap()
         self._create_backend_directory()
         self._generate_vault_config_file()
@@ -151,6 +150,9 @@ class VaultOperatorCharm(CharmBase):
         try:
             snap_cache = snap.SnapCache()
             vault_snap = snap_cache[VAULT_SNAP_NAME]
+            if vault_snap.latest:
+                return
+            self.unit.status = MaintenanceStatus("Installing Vault")
             vault_snap.ensure(
                 snap.SnapState.Latest, channel=VAULT_SNAP_CHANNEL, revision=VAULT_SNAP_REVISION
             )


### PR DESCRIPTION
This prevents two things:

1. Don't display the status message "Installing Vault" every time configure is run (unless we're actually installing Vault)
2. Stop spamming logs that say we're installing vault every time configure is run. 

Also refactors tests to use `MagicMock` instead of our own `MockSnapObject`

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
