### PR TITLE
chore: Uses track 1.15 to publish the charm

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -24,7 +24,7 @@ jobs:
       - unit-tests-with-coverage
     uses: ./.github/workflows/integration-tests.yaml
     with:
-      charm-file-name: "vault-dev_ubuntu-22.04-amd64.charm"
+      charm-file-name: "vault_ubuntu-22.04-amd64.charm"
     secrets: inherit
 
   publish-charm:
@@ -36,5 +36,5 @@ jobs:
     if: ${{ github.ref_name == 'main' }}
     uses: ./.github/workflows/publish-charm.yaml
     with:
-      charm-file-name: "vault-dev_ubuntu-22.04-amd64.charm"
+      charm-file-name: "vault_ubuntu-22.04-amd64.charm"
     secrets: inherit

--- a/.github/workflows/publish-charm.yaml
+++ b/.github/workflows/publish-charm.yaml
@@ -32,7 +32,7 @@ jobs:
           built-charm-path: ${{ inputs.charm-file-name }}
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-          channel: latest/edge
+          channel: 1.15/edge
 
       - name: Archive charmcraft logs
         if: failure()

--- a/README.md
+++ b/README.md
@@ -3,5 +3,5 @@
 ## Usage
 
 ```shell
-juju deploy vault-dev -n 5
+juju deploy vault -n 5
 ```

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,7 +1,7 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-name: vault-dev
+name: vault
 
 display-name: Vault
 summary: A tool for managing secrets
@@ -14,7 +14,7 @@ description: |
   network encryption-as-a-service, or generate AWS IAM/STS
   credentials, SQL/NoSQL databases, X.509 certificates,
   SSH credentials, and more.
-website: https://charmhub.io/vault-dev
+website: https://charmhub.io/vault
 source: https://github.com/canonical/vault-operator
 issues: https://github.com/canonical/vault-operator/issues
 docs: https://discourse.charmhub.io/t/vault-operator-machine/12983

--- a/tests/unit/config.hcl
+++ b/tests/unit/config.hcl
@@ -1,7 +1,7 @@
 ui      = true
 storage "raft" {
   path= "/var/snap/vault/common/raft"
-  node_id = "whatever-vault-dev/0"
+  node_id = "whatever-vault/0"
   }
 listener "tcp" {
   telemetry {


### PR DESCRIPTION
# Description

This PR aims to publish the charm on track `1.15` under the [vault](https://charmhub.io/vault) charm.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
