### PR TITLE
chore: use collect status to centralise status management

### DIFF
--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -83,7 +83,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 4
 
 
 # Regex to locate 7-bit C1 ANSI sequences
@@ -214,7 +214,7 @@ class Snap(object):
       - state: a `SnapState` representation of its install status
       - channel: "stable", "candidate", "beta", and "edge" are common
       - revision: a string representing the snap's revision
-      - confinement: "classic" or "strict"
+      - confinement: "classic", "strict", or "devmode"
     """
 
     def __init__(
@@ -475,6 +475,8 @@ class Snap(object):
         args = []
         if self.confinement == "classic":
             args.append("--classic")
+        if self.confinement == "devmode":
+            args.append("--devmode")
         if channel:
             args.append('--channel="{}"'.format(channel))
         if revision:
@@ -489,6 +491,7 @@ class Snap(object):
         channel: Optional[str] = "",
         cohort: Optional[str] = "",
         revision: Optional[str] = None,
+        devmode: bool = False,
         leave_cohort: Optional[bool] = False,
     ) -> None:
         """Refresh a snap.
@@ -497,6 +500,7 @@ class Snap(object):
           channel: the channel to install from
           cohort: optionally, specify a cohort.
           revision: optionally, specify the revision of the snap to refresh
+          devmode: optionally, specify devmode confinement
           leave_cohort: leave the current cohort.
         """
         args = []
@@ -505,6 +509,9 @@ class Snap(object):
 
         if revision:
             args.append('--revision="{}"'.format(revision))
+
+        if devmode:
+            args.append("--devmode")
 
         if not cohort:
             cohort = self._cohort
@@ -530,6 +537,7 @@ class Snap(object):
         self,
         state: SnapState,
         classic: Optional[bool] = False,
+        devmode: bool = False,
         channel: Optional[str] = "",
         cohort: Optional[str] = "",
         revision: Optional[str] = None,
@@ -539,6 +547,7 @@ class Snap(object):
         Args:
           state: a `SnapState` to reconcile to.
           classic: an (Optional) boolean indicating whether classic confinement should be used
+          devmode: an (Optional) boolean indicating whether devmode confinement should be used
           channel: the channel to install from
           cohort: optional. Specify the key of a snap cohort.
           revision: optional. the revision of the snap to install/refresh
@@ -549,7 +558,15 @@ class Snap(object):
         Raises:
           SnapError if an error is encountered
         """
-        self._confinement = "classic" if classic or self._confinement == "classic" else ""
+        if classic and devmode:
+            raise ValueError("Cannot set both classic and devmode confinement")
+
+        if classic or self._confinement == "classic":
+            self._confinement = "classic"
+        elif devmode or self._confinement == "devmode":
+            self._confinement = "devmode"
+        else:
+            self._confinement = ""
 
         if state not in (SnapState.Present, SnapState.Latest):
             # We are attempting to remove this snap.
@@ -566,7 +583,7 @@ class Snap(object):
                 self._install(channel, cohort, revision)
             else:
                 # The snap is installed, but we are changing it (e.g., switching channels).
-                self._refresh(channel, cohort, revision)
+                self._refresh(channel=channel, cohort=cohort, revision=revision, devmode=devmode)
 
         self._update_snap_apps()
         self._state = state
@@ -892,6 +909,7 @@ def add(
     state: Union[str, SnapState] = SnapState.Latest,
     channel: Optional[str] = "",
     classic: Optional[bool] = False,
+    devmode: bool = False,
     cohort: Optional[str] = "",
     revision: Optional[str] = None,
 ) -> Union[Snap, List[Snap]]:
@@ -903,6 +921,8 @@ def add(
             [`Present` or `Latest`]
         channel: an (Optional) channel as a string. Defaults to 'latest'
         classic: an (Optional) boolean specifying whether it should be added with classic
+            confinement. Default `False`
+        devmode: an (Optional) boolean specifying whether it should be added with devmode
             confinement. Default `False`
         cohort: an (Optional) string specifying the snap cohort to use
         revision: an (Optional) string specifying the snap revision to use
@@ -920,7 +940,7 @@ def add(
     if isinstance(state, str):
         state = SnapState(state)
 
-    return _wrap_snap_operations(snap_names, state, channel, classic, cohort, revision)
+    return _wrap_snap_operations(snap_names, state, channel, classic, devmode, cohort, revision)
 
 
 @_cache_init
@@ -936,8 +956,13 @@ def remove(snap_names: Union[str, List[str]]) -> Union[Snap, List[Snap]]:
     snap_names = [snap_names] if isinstance(snap_names, str) else snap_names
     if not snap_names:
         raise TypeError("Expected at least one snap to add, received zero!")
-
-    return _wrap_snap_operations(snap_names, SnapState.Absent, "", False)
+    return _wrap_snap_operations(
+        snap_names=snap_names,
+        state=SnapState.Absent,
+        channel="",
+        classic=False,
+        devmode=False,
+    )
 
 
 @_cache_init
@@ -946,6 +971,7 @@ def ensure(
     state: str,
     channel: Optional[str] = "",
     classic: Optional[bool] = False,
+    devmode: bool = False,
     cohort: Optional[str] = "",
     revision: Optional[int] = None,
 ) -> Union[Snap, List[Snap]]:
@@ -956,6 +982,8 @@ def ensure(
         state: a string representation of the desired state, from `SnapState`
         channel: an (Optional) channel as a string. Defaults to 'latest'
         classic: an (Optional) boolean specifying whether it should be added with classic
+            confinement. Default `False`
+        devmode: an (Optional) boolean specifying whether it should be added with devmode
             confinement. Default `False`
         cohort: an (Optional) string specifying the snap cohort to use
         revision: an (Optional) integer specifying the snap revision to use
@@ -970,7 +998,15 @@ def ensure(
         channel = "latest"
 
     if state in ("present", "latest") or revision:
-        return add(snap_names, SnapState(state), channel, classic, cohort, revision)
+        return add(
+            snap_names=snap_names,
+            state=SnapState(state),
+            channel=channel,
+            classic=classic,
+            devmode=devmode,
+            cohort=cohort,
+            revision=revision,
+        )
     else:
         return remove(snap_names)
 
@@ -980,6 +1016,7 @@ def _wrap_snap_operations(
     state: SnapState,
     channel: str,
     classic: bool,
+    devmode: bool,
     cohort: Optional[str] = "",
     revision: Optional[str] = None,
 ) -> Union[Snap, List[Snap]]:
@@ -995,7 +1032,12 @@ def _wrap_snap_operations(
                 snap.ensure(state=SnapState.Absent)
             else:
                 snap.ensure(
-                    state=state, classic=classic, channel=channel, cohort=cohort, revision=revision
+                    state=state,
+                    classic=classic,
+                    devmode=devmode,
+                    channel=channel,
+                    cohort=cohort,
+                    revision=revision,
                 )
             snaps["success"].append(snap)
         except SnapError as e:
@@ -1014,13 +1056,17 @@ def _wrap_snap_operations(
 
 
 def install_local(
-    filename: str, classic: Optional[bool] = False, dangerous: Optional[bool] = False
+    filename: str,
+    classic: Optional[bool] = False,
+    devmode: Optional[bool] = False,
+    dangerous: Optional[bool] = False,
 ) -> Snap:
     """Perform a snap operation.
 
     Args:
         filename: the path to a local .snap file to install
         classic: whether to use classic confinement
+        devmode: whether to use devmode confinement
         dangerous: whether --dangerous should be passed to install snaps without a signature
 
     Raises:
@@ -1033,6 +1079,8 @@ def install_local(
     ]
     if classic:
         args.append("--classic")
+    if devmode:
+        args.append("--devmode")
     if dangerous:
         args.append("--dangerous")
     try:

--- a/lib/charms/vault_k8s/v0/vault_tls.py
+++ b/lib/charms/vault_k8s/v0/vault_tls.py
@@ -20,11 +20,10 @@ from charms.tls_certificates_interface.v3.tls_certificates import (
     generate_csr,
     generate_private_key,
 )
+from exceptions import VaultCertsError
 from ops import EventBase, Object, RelationBrokenEvent, SecretNotFoundError
 from ops.charm import CharmBase
 from ops.pebble import APIError, PathError
-
-from exceptions import VaultCertsError
 
 # The unique Charmhub library identifier, never change it
 LIBID = "61b41a053d9847ce8a14eb02197d12cb"
@@ -34,7 +33,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 5
 
 
 logger = logging.getLogger(__name__)
@@ -60,7 +59,7 @@ VAULT_CA_SUBJECT = "Vault self signed CA"
 
 # TODO Move this class, it doesn't belong here.
 class WorkloadBase(ABC):
-    """Defines an interface for the Machine and Container classes."""
+    """Define an interface for the Machine and Container classes."""
 
     @abstractmethod
     def exists(self, path: str) -> bool:
@@ -117,7 +116,7 @@ class VaultTLSManager(Object):
         tls_directory_path: str,
         workload: WorkloadBase,
     ):
-        """Manager of TLS relation and configuration.
+        """Create a new VaultTLSManager object.
 
         Args:
             charm: CharmBase
@@ -163,7 +162,7 @@ class VaultTLSManager(Object):
         self.charm.on.config_changed.emit()
 
     def _on_tls_certificates_access_relation_broken(self, event: RelationBrokenEvent):
-        """Handles leaving the tls access relation.
+        """Handle leaving the tls access relation.
 
         Regenerates self signed certificates from the saved self generated root CA
         and reloads vault.
@@ -172,7 +171,7 @@ class VaultTLSManager(Object):
         self.charm.on.config_changed.emit()
 
     def configure_certificates(self, subject_ip: str) -> None:
-        """Configures the certificates that are used to connect to and communicate with Vault.
+        """Configure the certificates that are used to connect to and communicate with Vault.
 
         Args:
             subject_ip: The ip address for which the certificates will be configured for.
@@ -182,9 +181,9 @@ class VaultTLSManager(Object):
                 ca_private_key, ca_certificate = generate_vault_ca_certificate()
                 self._set_ca_certificate_secret(ca_private_key, ca_certificate)
                 tls_logger.info("Saved the Vault generated CA cert in juju secrets.")
-            if not self._tls_file_pushed_to_workload(
+            if not self.tls_file_pushed_to_workload(
                 File.CA
-            ) or not self._tls_file_pushed_to_workload(File.CERT):
+            ) or not self.tls_file_pushed_to_workload(File.CERT):
                 self._generate_self_signed_certs(subject_ip)
                 tls_logger.info(
                     "Saved Vault generated CA and self signed certificate to %s.",
@@ -212,7 +211,7 @@ class VaultTLSManager(Object):
             self._reload_vault()
 
     def send_ca_cert(self):
-        """Sends the existing CA cert in the workload to all relations."""
+        """Send the existing CA cert in the workload to all relations."""
         if ca := self.pull_tls_file_from_workload(File.CA):
             for relation in self.charm.model.relations.get(SEND_CA_CERT_RELATION_NAME, []):
                 self.certificate_transfer.set_certificate(
@@ -225,7 +224,7 @@ class VaultTLSManager(Object):
             tls_logger.info("Removed CA cert from relations")
 
     def _generate_self_signed_certs(self, subject_ip: str) -> None:
-        """Recreates a unit certificate from the Vault CA certificate, then saves it.
+        """Recreate a unit certificate from the Vault CA certificate, then saves it.
 
         Args:
             subject_ip: The subject of the unit certificate.
@@ -250,7 +249,7 @@ class VaultTLSManager(Object):
         self._push_tls_file_to_workload(File.CERT, certificate)
 
     def _should_request_new_certificate(self) -> bool:
-        """Determines if we should request a new certificate from the tls relation."""
+        """Determine if we should request a new certificate from the tls relation."""
         if not self.charm.model.relations.get(TLS_CERTIFICATE_ACCESS_RELATION_NAME):
             return False
 
@@ -259,12 +258,10 @@ class VaultTLSManager(Object):
         pending_csrs = self.tls_access.get_certificate_signing_requests(unfulfilled_only=True)
         expired_certs = self.tls_access.get_expiring_certificates()
 
-        existing_csr_is_fulfilled = any(
-            [existing_csr in csr_obj.csr for csr_obj in fulfilled_csrs]
-        )
-        existing_csr_is_pending = any([existing_csr in csr_obj.csr for csr_obj in pending_csrs])
+        existing_csr_is_fulfilled = any(existing_csr in csr_obj.csr for csr_obj in fulfilled_csrs)
+        existing_csr_is_pending = any(existing_csr in csr_obj.csr for csr_obj in pending_csrs)
         existing_csr_expiring = any(
-            [existing_csr in cert_obj.certificate for cert_obj in expired_certs]
+            existing_csr in cert_obj.certificate for cert_obj in expired_certs
         )
 
         if csr_is_in_workload:
@@ -277,7 +274,7 @@ class VaultTLSManager(Object):
     def _send_new_certificate_request_to_provider(
         self, old_csr: Optional[str], subject_ip: str
     ) -> None:
-        """This function creates and sends a new certificate signing request to the provider.
+        """Create and send a new certificate signing request to the provider.
 
         Args:
             old_csr: Optional value that is used to decide wether to send a renewal or new request.
@@ -300,7 +297,7 @@ class VaultTLSManager(Object):
             self.tls_access.request_certificate_creation(new_csr)
 
     def get_tls_file_path_in_charm(self, file: File) -> str:
-        """Returns the requested file's location in the charm (not in the workload).
+        """Return the requested file's location in the charm (not in the workload).
 
         This path would typically be: /var/lib/juju/storage/certs/0/{file}.pem
 
@@ -319,6 +316,20 @@ class VaultTLSManager(Object):
         cert_storage = storage["certs"][0]
         storage_location = cert_storage.location
         return f"{storage_location}/{file.name.lower()}.pem"
+
+    def tls_file_available_in_charm(self, file: File) -> bool:
+        """Return whether the given file is available in the charm.
+
+        Args:
+            file: a File object that determines which file to check
+        Returns:
+            bool: True if file exists
+        """
+        try:
+            self.get_tls_file_path_in_charm(file)
+            return True
+        except VaultCertsError:
+            return False
 
     def _get_ca_certificate_secret(self) -> Tuple[str, str]:
         """Get the vault CA certificate secret.
@@ -353,7 +364,7 @@ class VaultTLSManager(Object):
         secret.set_content(juju_secret_content)
 
     def ca_certificate_secret_exists(self) -> bool:
-        """Returns whether CA certificate is stored in secret."""
+        """Return whether CA certificate is stored in secret."""
         try:
             ca_private_key, ca_certificate = self._get_ca_certificate_secret()
             if ca_private_key and ca_certificate:
@@ -363,25 +374,23 @@ class VaultTLSManager(Object):
         return False
 
     def ca_certificate_is_saved(self) -> bool:
-        """Returns wether a CA cert is saved in the charm."""
-        return self.ca_certificate_secret_exists() or self._tls_file_pushed_to_workload(File.CA)
+        """Return wether a CA cert is saved in the charm."""
+        return self.ca_certificate_secret_exists() or self.tls_file_pushed_to_workload(File.CA)
 
     def _remove_all_certs_from_workload(self) -> None:
-        """Removes the certificate files that are used for authentication."""
+        """Remove the certificate files that are used for authentication."""
         self._remove_tls_file_from_workload(File.CA)
         self._remove_tls_file_from_workload(File.CERT)
         self._remove_tls_file_from_workload(File.CSR)
         tls_logger.debug("Removed existing certificate files from workload.")
 
     def _reload_vault(self) -> None:
-        """Sends a SIGHUP signal to the process running Vault.
+        """Send a SIGHUP signal to the process running Vault.
 
         Reloads Vault's files and fails gracefully.
         """
         try:
-            self.workload.send_signal(
-                signal=SIGHUP, process=self._service_name
-            )
+            self.workload.send_signal(signal=SIGHUP, process=self._service_name)
             tls_logger.debug("Vault restart requested")
         except APIError:
             tls_logger.debug("Couldn't send signal to process. Proceeding normally.")
@@ -415,7 +424,7 @@ class VaultTLSManager(Object):
         tls_logger.debug("Pushed %s file to workload", file.name)
 
     def _remove_tls_file_from_workload(self, file: File) -> None:
-        """Removes the certificate files that are used for authentication.
+        """Remove the certificate files that are used for authentication.
 
         Args:
             file: a File object that determines which file to remove.
@@ -426,8 +435,8 @@ class VaultTLSManager(Object):
             pass
         tls_logger.debug("Removed %s file from workload.", file.name)
 
-    def _tls_file_pushed_to_workload(self, file: File) -> bool:
-        """Returns whether tls file is pushed to the workload.
+    def tls_file_pushed_to_workload(self, file: File) -> bool:
+        """Return whether tls file is pushed to the workload.
 
         Args:
             file: a File object that determines which file to check.
@@ -470,6 +479,7 @@ def generate_vault_unit_certificate(
         sans_dns: List of DNS subject alternative names
         ca_certificate: CA certificate
         ca_private_key: CA private key
+        unit_private_key: Unit private key
 
     Returns:
         Tuple[str, str]: Unit private key, Unit certificate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,9 +53,6 @@ copyright-check = "True"
 copyright-author = "Canonical Ltd."
 copyright-regexp = "Copyright\\s\\d{4}([-,]\\d{4})*\\s+%(author)s"
 
-[tool.ruff.mccabe]
-max-complexity = 10
-
 [tool.codespell]
 skip = "build,lib,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.coverage"
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -19,7 +19,7 @@ from jinja2 import Environment, FileSystemLoader
 from machine import Machine
 from ops.charm import CharmBase, CollectStatusEvent
 from ops.main import main
-from ops.model import ActiveStatus, ModelError, WaitingStatus
+from ops.model import ActiveStatus, MaintenanceStatus, ModelError, WaitingStatus
 
 logger = logging.getLogger(__name__)
 
@@ -189,6 +189,7 @@ class VaultOperatorCharm(CharmBase):
             vault_snap = snap_cache[VAULT_SNAP_NAME]
             if vault_snap.latest:
                 return
+            self.unit.status = MaintenanceStatus("Installing Vault")
             vault_snap.ensure(
                 snap.SnapState.Latest, channel=VAULT_SNAP_CHANNEL, revision=VAULT_SNAP_REVISION
             )

--- a/src/charm.py
+++ b/src/charm.py
@@ -153,7 +153,7 @@ class VaultOperatorCharm(CharmBase):
         if not self.tls.tls_file_pushed_to_workload(File.CA):
             event.add_status(WaitingStatus("Waiting for CA certificate in workload"))
             return
-        if not self._vault_service_started():
+        if not self._is_vault_service_started():
             event.add_status(WaitingStatus("Waiting for Vault service to start"))
             return
         event.add_status(ActiveStatus())
@@ -279,7 +279,7 @@ class VaultOperatorCharm(CharmBase):
             if node_api_address != self._api_address
         ]
 
-    def _vault_service_started(self) -> bool:
+    def _is_vault_service_started(self) -> bool:
         """Check if the Vault service is started."""
         snap_cache = snap.SnapCache()
         vault_snap = snap_cache[VAULT_SNAP_NAME]

--- a/src/charm.py
+++ b/src/charm.py
@@ -287,7 +287,7 @@ class VaultOperatorCharm(CharmBase):
         vaultd_service = vault_services.get("vaultd")
         if not vaultd_service:
             return False
-        if not vaultd_service["enabled"] or not vaultd_service["active"]:
+        if not vaultd_service["active"]:
             return False
         return True
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -162,14 +162,14 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(pushed_content_hcl, expected_content_hcl)
 
     @patch("ops.model.Model.get_binding")
-    def test_given_bind_address_unavailable_when_configure_then_status_is_waiting(
+    def test_given_bind_address_unavailable_when_collectstatus_then_status_is_waiting(
         self, patch_get_binding
     ):
         patch_get_binding.return_value = None
         self.harness.set_leader(is_leader=False)
         self._set_peer_relation()
 
-        self.harness.charm.on.install.emit()
+        self.harness.evaluate_status()
 
         self.assertEqual(
             self.harness.charm.unit.status,
@@ -177,14 +177,14 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("ops.model.Model.get_binding")
-    def test_given_unit_not_leader_and_peer_addresses_unavailable_when_configure_then_status_is_waiting(
+    def test_given_unit_not_leader_and_peer_addresses_unavailable_when_collectstatus_then_status_is_waiting(
         self, patch_get_binding
     ):
         patch_get_binding.return_value = MockBinding(bind_address="1.2.1.2")
         self.harness.set_leader(is_leader=False)
         self._set_peer_relation()
 
-        self.harness.charm.on.install.emit()
+        self.harness.evaluate_status()
 
         self.assertEqual(
             self.harness.charm.unit.status,
@@ -192,7 +192,7 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("ops.model.Model.get_binding")
-    def test_given_unit_is_leader_and_ca_certificate_saved_when_configure_then_status_is_waiting(
+    def test_given_unit_is_leader_and_ca_certificate_saved_when_collectstatus_then_status_is_waiting(
         self,
         patch_get_binding,
     ):
@@ -208,11 +208,11 @@ class TestCharm(unittest.TestCase):
             relation_id=peer_relation_id, unit_name=other_unit_name
         )
 
-        self.harness.charm.on.install.emit()
+        self.harness.evaluate_status()
 
         self.assertEqual(
             self.harness.charm.unit.status,
-            WaitingStatus("Waiting for CA certificate to be set."),
+            WaitingStatus("Waiting for CA certificate in workload"),
         )
 
     @patch("charms.vault_k8s.v0.vault_tls.VaultTLSManager.configure_certificates", new=Mock())
@@ -318,7 +318,7 @@ class TestCharm(unittest.TestCase):
     @patch("charm.config_file_content_matches", new=Mock())
     @patch("ops.model.Model.get_binding")
     @patch("charms.operator_libs_linux.v2.snap.SnapCache")
-    def test_given_unit_not_leader_and_peer_addresses_available_when_configure_then_status_is_active(
+    def test_given_unit_not_leader_and_peer_addresses_available_when_collectstatus_then_status_is_active(
         self,
         _,
         patch_get_binding,
@@ -339,7 +339,7 @@ class TestCharm(unittest.TestCase):
             relation_id=peer_relation_id, unit_name=other_unit_name
         )
 
-        self.harness.charm.on.install.emit()
+        self.harness.evaluate_status()
 
         self.assertEqual(
             self.harness.charm.unit.status,


### PR DESCRIPTION
# Description

Use collect status to centralise status management. We will need this change to implement the `vault-pki` behavior as it was done in the K8s version of the charm. 

## Note

We also bump the charm libs version as recent changes in vault_k8s lib were used here. 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
