### PR TITLE
chore: add update-libs workflow

### DIFF
--- a/.github/workflows/update-libs.yaml
+++ b/.github/workflows/update-libs.yaml
@@ -1,0 +1,54 @@
+name: Auto-update Charm Libraries
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0,12 * * *"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-lib:
+    name: Check libraries
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up SSH Key for Signing Commits
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.BOT_PRIVATE_SIGNING_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          echo "${{ secrets.BOT_PUBLIC_SIGNING_KEY }}" > ~/.ssh/id_rsa.pub
+          chmod 644 ~/.ssh/id_rsa.pub
+          git config --global user.email "telco-engineers@lists.canonical.com"
+          git config --global user.name "telcobot"
+          git config --global user.signingkey ~/.ssh/id_rsa.pub
+          git config --global commit.gpgsign true
+          git config --global gpg.format ssh
+
+      - name: Fetch charm libraries
+        run: |
+          sudo snap install charmcraft --classic --channel latest/stable
+          charmcraft fetch-lib
+        env:
+          CHARMCRAFT_AUTH: "${{ secrets.CHARMCRAFT_AUTH }}"
+
+      - name: Create a PR for local changes
+        uses: peter-evans/create-pull-request@v6.0.0
+        with:
+          token: ${{ secrets.TELCO_GITHUB_BOT_TOKEN }}
+          commit-message: "chore: update charm libraries"
+          committer: "Telcobot <telco-engineers@lists.canonical.com>"
+          author: "Telcobot <telco-engineers@lists.canonical.com>"
+          title: "chore: Update charm libraries"
+          body: |
+            Automated action to fetch latest version of charm libraries. The branch of this PR 
+            will be wiped during the next check. Unless you really know what you're doing, you 
+            most likely don't want to push any commits to this branch.
+          branch: "chore/auto-libs"
+          delete-branch: true


### PR DESCRIPTION
# Description

Add update-libs workflow to automatically fetch new versions of charm libraries. 

## Note

We need to add the following github secrets first:
- BOT_PRIVATE_SIGNING_KEY
- BOT_PUBLIC_SIGNING_KEY
- TELCO_GITHUB_BOT_TOKEN

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
