### PR TITLE
perf: Install the Vault snap immediately

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -165,6 +165,7 @@ class VaultOperatorCharm(CharmBase):
           - Installing the Vault snap
           - Generating the Vault config file
         """
+        self._install_vault_snap()
         if not self._is_peer_relation_created():
             return
         if not self._bind_address:
@@ -173,7 +174,6 @@ class VaultOperatorCharm(CharmBase):
             return
         if not self.unit.is_leader() and not self.tls.ca_certificate_is_saved():
             return
-        self._install_vault_snap()
         self._create_backend_directory()
         self._create_certs_directory()
         self.tls.configure_certificates(self._bind_address)


### PR DESCRIPTION
This cuts the waiting time significantly when multiple Vault units are started on initial deploy. Before this change, all units that were not the leader would wait until the leader had finished installing Vault before they would install Vault.

As part of this, some fixes needed to be made to the tests.

- The snap cache wasn't being mocked properly, and was attempting to install the snap on the machine running the tests. This change mocks the snap cache at the class level to avoid mishaps in the future.

- The vault TLS manager is mocked on set-up for the same reason -- to avoid accidental calls to the external library. For some reason this worked for the TLS manager, but not the snap cache. I'm not entirely sure why.

- `test_given_unit_is_leader_and_ca_certificate_saved_when_collectstatus_then_status_is_waiting` was changed to expect an active status, which I _think_ makes more sense. It's not entirely clear to me why it was waiting on certificates when thet title states the certificates are saved.

# Description

Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
