### PR TITLE
fix: Add temp_maintenance_status contextmanager

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -141,7 +141,7 @@ class VaultOperatorCharm(CharmBase):
         self.framework.observe(self.on[PEER_RELATION_NAME].relation_changed, self._configure)
 
     @contextmanager
-    def temp_maintenance_status(self: CharmBase, message: str):
+    def temp_maintenance_status(self, message: str):
         """Context manager to set the charm status temporarily.
 
         Useful around long-running operations to indicate that the charm is


### PR DESCRIPTION
This allows us to temporarily set the status of the charm during a long running operation, and then restore it to the previous state once the operation is complete.

Before this change, the "Installing Vault" status message would continue to be set for the remainder of the hook.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
