### PR TITLE
chore: Update `vault_tls`, implement `restart()`

### DIFF
--- a/src/machine.py
+++ b/src/machine.py
@@ -4,7 +4,6 @@
 
 """Machine abstraction for the Vault charm."""
 
-
 import logging
 import os
 import shutil
@@ -13,6 +12,7 @@ from pathlib import Path
 from typing import Optional, TextIO
 
 import psutil
+from charms.operator_libs_linux.v2 import snap
 from charms.vault_k8s.v0.vault_tls import WorkloadBase
 
 logger = logging.getLogger(__name__)
@@ -93,6 +93,12 @@ class Machine(WorkloadBase):
         if pid := self._find_process(process):
             os.kill(pid, signal)
             logger.info("Sent signal %s to charm", signal)
+
+    def restart(self, process: str) -> None:
+        """Restarts all services specified in the snap."""
+        snap_cache = snap.SnapCache()
+        vault_snap = snap_cache[process]
+        vault_snap.restart()
 
     def stop(self, process: str) -> None:
         """Stop a process.


### PR DESCRIPTION
Auto-update libs workflow isn't working because of a permission error I haven't resolved yet, but also this needs manual intervention since `restart()` needs to be implemented to pass the tests anyway. 

This is yet another pre-requisite to get #62 working properly with TLS certificates.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
