### PR TITLE
build: Validate tests with pyright

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -138,7 +138,8 @@ async def test_given_certificates_provider_is_related_when_vault_status_checked_
         status="active",
         timeout=1000,
     )
-    unit_ip = ops_test.model.units.get(f"{APP_NAME}/0").public_address
+    assert isinstance(unit := ops_test.model.units.get(f"{APP_NAME}/0"), Unit)
+    unit_ip = unit.public_address
     vault_endpoint = f"https://{unit_ip}:8200"
     action_output = await run_get_ca_certificate_action(ops_test)
     ca_certificate = action_output["ca-certificate"]

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ commands =
 [testenv:static]
 description = Run static type checks
 commands =
-    pyright {posargs}
+    pyright {posargs} {[vars]all_path}
 
 [testenv:unit]
 description = Run unit tests


### PR DESCRIPTION
Not providing any parameters only validates the code in `src/`  -- this change adds the tests to the code validated by `pyright`

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
