### PR TITLE
feat: implement upstream side of pki integration

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -10,3 +10,8 @@ options:
     type: string
     default: "720h"
     description: Specifies the maximum possible lease duration for Vault's tokens and secrets.
+  common_name:
+    type: string
+    description: |
+      The common name that will be used by Vault as an intermediate CA. This will only be used when the charm is 
+      configured to use a Vault PKI backend through the `vault-pki` relation.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -50,3 +50,9 @@ requires:
     description: |
       Communication between the vault units and from a client to Vault should 
       be done using the certificates provided by this integration.
+  tls-certificates-pki:
+    interface: tls-certificates
+    limit: 1
+    description: |
+      Interface to be used to provide Vault with its CA certificate. Vault will
+      use this certificate to sign the certificates it issues on the `vault-pki` interface.

--- a/src/charm.py
+++ b/src/charm.py
@@ -57,7 +57,7 @@ VAULT_SNAP_NAME = "vault"
 VAULT_SNAP_REVISION = "2181"
 VAULT_STORAGE_PATH = "/var/snap/vault/common/raft"
 VAULT_PKI_MOUNT = "charm-pki"
-VAULT_PKI_ROLE = "charm"
+VAULT_PKI_ROLE = "charm-pki"
 
 
 def render_vault_config_file(

--- a/src/charm.py
+++ b/src/charm.py
@@ -314,7 +314,7 @@ class VaultOperatorCharm(CharmBase):
         self._start_vault_service()
         self._set_peer_relation_node_api_address()
         self._configure_pki_secrets_engine()
-        self._add_ca_certificate_to_pki_secrets_engine()
+        self._add_intermediate_ca_certificate_to_pki_secrets_engine()
         self.tls.send_ca_cert()
 
         if not self._api_address or not self.tls.tls_file_available_in_charm(File.CA):
@@ -340,7 +340,7 @@ class VaultOperatorCharm(CharmBase):
 
     def _on_tls_certificate_pki_certificate_available(self, _: CertificateAvailableEvent):
         """Handle the tls-certificates-pki certificate available event."""
-        self._add_ca_certificate_to_pki_secrets_engine()
+        self._add_intermediate_ca_certificate_to_pki_secrets_engine()
 
     def _configure_pki_secrets_engine(self) -> None:
         """Configure the PKI secrets engine."""
@@ -383,7 +383,7 @@ class VaultOperatorCharm(CharmBase):
         intermediate_ca_common_name = get_common_name_from_certificate(intermediate_ca)
         return intermediate_ca_common_name == common_name
 
-    def _add_ca_certificate_to_pki_secrets_engine(self) -> None:
+    def _add_intermediate_ca_certificate_to_pki_secrets_engine(self) -> None:
         """Add the CA certificate to the PKI secrets engine."""
         if not self.unit.is_leader():
             logger.debug("Only leader unit can handle a vault-pki certificate request")
@@ -404,7 +404,7 @@ class VaultOperatorCharm(CharmBase):
         if not common_name:
             logger.error("Common name is not set in the charm config")
             return
-        certificate = self._get_pki_ca_certificate()
+        certificate = self._get_pki_intermediate_ca_certificate()
         if not certificate:
             logger.debug("No certificate available")
             return
@@ -417,7 +417,7 @@ class VaultOperatorCharm(CharmBase):
                 role=VAULT_PKI_ROLE,
             )
 
-    def _get_pki_ca_certificate(self) -> Optional[str]:
+    def _get_pki_intermediate_ca_certificate(self) -> Optional[str]:
         """Return the PKI CA certificate provided by the TLS provider.
 
         Validate that the CSR matches the one in secrets.

--- a/src/charm.py
+++ b/src/charm.py
@@ -356,6 +356,9 @@ class VaultOperatorCharm(CharmBase):
         ):
             logger.debug("Vault is not ready to handle a vault-pki certificate request, skipping")
             return
+        if not (approle_auth := self._get_vault_approle_secret()):
+            return
+        vault.authenticate(AppRole(approle_auth[0], approle_auth[1]))
         if not self._tls_certificates_pki_relation_created():
             logger.debug("TLS Certificates PKI relation not created, skipping")
             return
@@ -394,6 +397,9 @@ class VaultOperatorCharm(CharmBase):
         ):
             logger.debug("Vault is not ready to handle a vault-pki certificate request")
             return
+        if not (approle_auth := self._get_vault_approle_secret()):
+            return
+        vault.authenticate(AppRole(approle_auth[0], approle_auth[1]))
         common_name = self._get_config_common_name()
         if not common_name:
             logger.error("Common name is not set in the charm config")

--- a/src/templates/charm_policy.hcl
+++ b/src/templates/charm_policy.hcl
@@ -37,3 +37,8 @@ path "sys/mounts/" {
 path "sys/storage/raft/autopilot/state" {
   capabilities = ["read"]
 }
+
+# Allow operations under the charm prefix
+path "charm-*" {
+  capabilities = [ "create", "read", "update", "delete", "list", "sudo" ]
+}

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -90,6 +90,7 @@ async def build_and_deploy(ops_test: OpsTest):
         application_name=APP_NAME,
         trust=True,
         num_units=NUM_VAULT_UNITS,
+        config={"common_name": "example.com"},
     )
 
 
@@ -122,7 +123,7 @@ async def deploy_self_signed_certificates_operator(ops_test: OpsTest):
         SELF_SIGNED_CERTIFICATES_APPLICATION_NAME,
         application_name=SELF_SIGNED_CERTIFICATES_APPLICATION_NAME,
         trust=True,
-        channel="beta",
+        channel="stable",
     )
 
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -263,3 +263,18 @@ async def test_given_grafana_agent_deployed_when_relate_to_grafana_agent_then_st
             status="active",
             timeout=1000,
         )
+
+@pytest.mark.abort_on_fail
+async def test_given_tls_certificates_pki_relation_when_integrate_then_status_is_active(
+    ops_test: OpsTest, build_and_deploy, deploy_self_signed_certificates_operator
+):
+    assert ops_test.model
+    await ops_test.model.integrate(
+        relation1=f"{APP_NAME}:tls-certificates-pki",
+        relation2=f"{SELF_SIGNED_CERTIFICATES_APPLICATION_NAME}:certificates",
+    )
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME, SELF_SIGNED_CERTIFICATES_APPLICATION_NAME],
+        status="active",
+        timeout=1000,
+    )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -17,12 +17,18 @@ from charm import (
     config_file_content_matches,
 )
 from charms.operator_libs_linux.v2.snap import Snap, SnapState
-from charms.vault_k8s.v0.vault_client import AuditDeviceType, Token, Vault
+from charms.tls_certificates_interface.v3.tls_certificates import (
+    CertificateAvailableEvent,
+    ProviderCertificate,
+)
+from charms.vault_k8s.v0.vault_client import AuditDeviceType, SecretsBackend, Token, Vault
 from charms.vault_k8s.v0.vault_tls import CA_CERTIFICATE_JUJU_SECRET_LABEL
 
 PEER_RELATION_NAME = "vault-peers"
 VAULT_STORAGE_PATH = "/var/snap/vault/common/raft"
-
+VAULT_PKI_CSR_SECRET_LABEL = "pki-csr"
+TLS_CERTIFICATES_LIB_PATH = "charms.tls_certificates_interface.v3.tls_certificates"
+TLS_CERTIFICATES_PKI_RELATION_NAME = "tls-certificates-pki"
 
 class MockNetwork:
     def __init__(self, bind_address: str):
@@ -92,6 +98,7 @@ class TestCharm(unittest.TestCase):
         self.mock_machine = TestCharm.patcher_machine.start().return_value
         self.mock_vault = TestCharm.patcher_vault.start().return_value
 
+        self.app_name = "vault"
         self.model_name = "whatever"
         self.harness = ops.testing.Harness(VaultOperatorCharm)
         self.harness.set_model_name(self.model_name)
@@ -133,6 +140,25 @@ class TestCharm(unittest.TestCase):
             secret = self.harness.model.get_secret(id=secret_id)
             secret.set_info(label=CA_CERTIFICATE_JUJU_SECRET_LABEL)
             self.harness.set_leader(original_leader_state)
+
+    def _set_csr_secret_in_peer_relation(self, relation_id: int, csr: str) -> None:
+        """Set the csr secret in the peer relation."""
+        content = {
+            "csr": csr,
+        }
+        original_leader_state = self.harness.charm.unit.is_leader()
+        with self.harness.hooks_disabled():
+            self.harness.set_leader(is_leader=True)
+            secret_id = self.harness.add_model_secret(owner=self.app_name, content=content)
+            secret = self.harness.model.get_secret(id=secret_id)
+            secret.set_info(label=VAULT_PKI_CSR_SECRET_LABEL)
+            self.harness.set_leader(original_leader_state)
+        key_values = {"vault-pki-csr-secret-id": secret_id}
+        self.harness.update_relation_data(
+            app_or_unit=self.app_name,
+            relation_id=relation_id,
+            key_values=key_values,
+        )
 
     @patch("charm.config_file_content_matches", new=Mock())
     @patch("ops.model.Model.get_binding")
@@ -403,3 +429,100 @@ class TestCharm(unittest.TestCase):
 
         assert secret_content["role-id"] == "approle_id"
         assert secret_content["secret-id"] == "secret_id"
+
+    @patch("charm.get_common_name_from_certificate", new=Mock)
+    @patch(f"{TLS_CERTIFICATES_LIB_PATH}.TLSCertificatesRequiresV3.request_certificate_creation")
+    @patch("ops.model.Model.get_binding")
+    def test_given_vault_is_available_when_tls_certificates_pki_relation_joined_then_certificate_request_is_made(
+        self,
+        patch_get_binding,
+        patch_request_certificate_creation,
+    ):
+        self._set_peer_relation()
+        patch_get_binding.return_value = MockBinding(bind_address="1.2.1.2")
+        csr = "some csr content"
+        self.mock_vault.configure_mock(
+            spec=Vault,
+            **{
+                "is_initialized.return_value": True,
+                "is_api_available.return_value": True,
+                "is_sealed.return_value": False,
+                "get_intermediate_ca.return_value": "vault",
+                "generate_pki_intermediate_ca_csr.return_value": csr,
+            },
+        )
+        self.harness.update_config({"common_name": "vault"})
+        self.harness.set_leader(is_leader=True)
+        relation_id = self.harness.add_relation(
+            relation_name=TLS_CERTIFICATES_PKI_RELATION_NAME, remote_app="tls-provider"
+        )
+
+        self.harness.add_relation_unit(relation_id, "tls-provider/0")
+
+        self.mock_vault.enable_secrets_engine.assert_called_with(SecretsBackend.PKI, "charm-pki")
+        self.mock_vault.generate_pki_intermediate_ca_csr.assert_called_with(
+            mount="charm-pki", common_name="vault"
+        )
+        patch_request_certificate_creation.assert_called_with(
+            certificate_signing_request=csr.encode(), is_ca=True
+        )
+
+    @patch("ops.model.Model.get_binding")
+    @patch(f"{TLS_CERTIFICATES_LIB_PATH}.TLSCertificatesRequiresV3.get_assigned_certificates")
+    def test_given_vault_is_available_when_pki_certificate_is_available_then_certificate_added_to_vault_pki(
+        self,
+        patch_get_assigned_certificates,
+        patch_get_binding,
+    ):
+        peer_relation_id = self._set_peer_relation()
+        patch_get_binding.return_value = MockBinding(bind_address="1.2.1.2")
+        self.mock_vault.configure_mock(
+            spec=Vault,
+            **{
+                "is_initialized.return_value": True,
+                "is_api_available.return_value": True,
+                "is_sealed.return_value": False,
+                "is_intermediate_ca_set.return_value": False,
+                "is_pki_role_created.return_value": False,
+            },
+        )
+
+        csr = "some csr content"
+        certificate = "some certificate"
+        ca = "some ca"
+        chain = [ca]
+        self.harness.update_config({"common_name": "vault"})
+        self.harness.set_leader(is_leader=True)
+
+        self._set_csr_secret_in_peer_relation(relation_id=peer_relation_id, csr="some csr content")
+        event = CertificateAvailableEvent(
+            handle=Mock(),
+            certificate=certificate,
+            certificate_signing_request=csr,
+            ca=ca,
+            chain=chain,
+        )
+        relation_id = self.harness.add_relation(
+            relation_name=TLS_CERTIFICATES_PKI_RELATION_NAME, remote_app="tls-provider"
+        )
+        patch_get_assigned_certificates.return_value = [
+            ProviderCertificate(
+                relation_id=relation_id,
+                application_name="tls-provider",
+                csr=csr,
+                certificate=certificate,
+                ca=ca,
+                chain=chain,
+                revoked=False,
+            )
+        ]
+
+        self.harness.charm._on_tls_certificate_pki_certificate_available(event)
+
+        self.mock_vault.set_pki_intermediate_ca_certificate.assert_called_with(
+            certificate=certificate,
+            mount="charm-pki",
+        )
+        self.mock_vault.create_pki_charm_role.assert_called_with(
+            allowed_domains="vault", mount="charm-pki", role="charm"
+        )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -532,5 +532,5 @@ class TestCharm(unittest.TestCase):
             mount="charm-pki",
         )
         self.mock_vault.create_pki_charm_role.assert_called_with(
-            allowed_domains="vault", mount="charm-pki", role="charm"
+            allowed_domains="vault", mount="charm-pki", role="charm-pki"
         )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -13,6 +13,7 @@ from charm import (
     VAULT_CHARM_POLICY_NAME,
     VAULT_CHARM_POLICY_PATH,
     VAULT_DEFAULT_POLICY_NAME,
+    VAULT_PKI_CSR_SECRET_LABEL,
     VaultOperatorCharm,
     config_file_content_matches,
 )
@@ -26,7 +27,6 @@ from charms.vault_k8s.v0.vault_tls import CA_CERTIFICATE_JUJU_SECRET_LABEL
 
 PEER_RELATION_NAME = "vault-peers"
 VAULT_STORAGE_PATH = "/var/snap/vault/common/raft"
-VAULT_PKI_CSR_SECRET_LABEL = "pki-csr"
 TLS_CERTIFICATES_LIB_PATH = "charms.tls_certificates_interface.v3.tls_certificates"
 TLS_CERTIFICATES_PKI_RELATION_NAME = "tls-certificates-pki"
 
@@ -441,6 +441,10 @@ class TestCharm(unittest.TestCase):
         self._set_peer_relation()
         patch_get_binding.return_value = MockBinding(bind_address="1.2.1.2")
         csr = "some csr content"
+        self.harness.charm.app.add_secret(
+            {"role-id": "role-id", "secret-id": "secret-id"},
+            label=VAULT_CHARM_APPROLE_SECRET_LABEL,
+        )
         self.mock_vault.configure_mock(
             spec=Vault,
             **{
@@ -476,6 +480,10 @@ class TestCharm(unittest.TestCase):
     ):
         peer_relation_id = self._set_peer_relation()
         patch_get_binding.return_value = MockBinding(bind_address="1.2.1.2")
+        self.harness.charm.app.add_secret(
+            {"role-id": "role-id", "secret-id": "secret-id"},
+            label=VAULT_CHARM_APPROLE_SECRET_LABEL,
+        )
         self.mock_vault.configure_mock(
             spec=Vault,
             **{


### PR DESCRIPTION
# Description

Vault can now act as an intermediate CA where the parent CA is the provider side of the newly added tls-certificates-pki integration. Here we add the requirer side of the pki integration .

Upon certificates-pki-request relation joined:
- Configure the PKI mount, configures the PKI intermediate CA (generates a CSR)
- Send that CSR over to the relation provider.
- Store the CSR in a Juju secret

Upon Certificate Available:
- Validate that the received cert matches the stored CSR
- Set the PKI intermediate CA certificate
- Set the PKI charm role

## Notes
1. This task is the equivalent of this one made in the K8s charm: 
    - https://github.com/canonical/vault-k8s-operator/pull/180
2. A follow up PR will implement the provider side where requires will be able to integrate with Vault using the tls-certificates integration that we will alias to vault-pki.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
