### PR TITLE
feat: implement downstream side of pki integration

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -36,6 +36,8 @@ peers:
     interface: vault-peer
 
 provides:
+  vault-pki:
+    interface: tls-certificates
   cos-agent:
     interface: cos_agent
   send-ca-cert:

--- a/src/charm.py
+++ b/src/charm.py
@@ -365,7 +365,6 @@ class VaultOperatorCharm(CharmBase):
             logger.debug("Only leader unit can handle a vault-pki certificate request")
             return
         if not self._tls_certificates_pki_relation_created():
-            print(3)
             logger.debug("TLS Certificates PKI relation not created")
             return
         vault = self._get_vault_client()
@@ -375,7 +374,6 @@ class VaultOperatorCharm(CharmBase):
             or not vault.is_initialized()
             or vault.is_sealed()
         ):
-            print(5)
             return
         if not (approle_auth := self._get_vault_approle_secret()):
             return

--- a/src/charm.py
+++ b/src/charm.py
@@ -406,15 +406,12 @@ class VaultOperatorCharm(CharmBase):
 
     def _sync_vault_pki(self) -> None:
         """Goes through all the vault-pki relations and sends necessary TLS certificate."""
-        for relation in self.model.relations[PKI_RELATION_NAME]:
-            outstanding_requests = self.vault_pki.get_outstanding_certificate_requests(
-                relation_id=relation.id
+        outstanding_requests = self.vault_pki.get_outstanding_certificate_requests()
+        for request in outstanding_requests:
+            self._generate_pki_certificate_for_requirer(
+                csr=request.csr,
+                relation_id=request.relation_id,
             )
-            for request in outstanding_requests:
-                self._generate_pki_certificate_for_requirer(
-                    csr=request.csr,
-                    relation_id=relation.id,
-                )
 
     def _configure_pki_secrets_engine(self) -> None:
         """Configure the PKI secrets engine."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -257,6 +257,16 @@ class VaultOperatorCharm(CharmBase):
 
     def _on_collect_status(self, event: CollectStatusEvent):  # noqa: C901
         """Handle the collect status event."""
+        if (
+            self._tls_certificates_pki_relation_created()
+            and not self._common_name_config_is_valid()
+        ):
+            event.add_status(
+                BlockedStatus(
+                    "Common name is not set in the charm config, cannot configure PKI secrets engine"
+                )
+            )
+            return
         if not self._is_peer_relation_created():
             event.add_status(WaitingStatus("Waiting for peer relation"))
             return

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -79,7 +79,7 @@ async def get_leader(app: Application) -> Unit | None:
             return unit
     return None
 
-async def run_get_certificate_action(ops_test) -> dict:
+async def run_get_certificate_action(ops_test: OpsTest) -> dict:
     """Run `get-certificate` on the `tls-requirer-requirer/0` unit.
 
     Args:
@@ -138,7 +138,6 @@ async def deploy_self_signed_certificates_operator(ops_test: OpsTest):
     await ops_test.model.deploy(
         SELF_SIGNED_CERTIFICATES_APPLICATION_NAME,
         application_name=SELF_SIGNED_CERTIFICATES_APPLICATION_NAME,
-        trust=True,
         channel="stable",
     )
 
@@ -154,7 +153,6 @@ async def deploy_tls_certificates_requirer_operator(ops_test: OpsTest):
     await ops_test.model.deploy(
         VAULT_PKI_REQUIRER_APPLICATION_NAME,
         application_name=VAULT_PKI_REQUIRER_APPLICATION_NAME,
-        trust=True,
         channel="stable",
         config={"common_name": "test.example.com"},
     )

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -88,7 +88,9 @@ async def run_get_certificate_action(ops_test: OpsTest) -> dict:
     Returns:
         dict: Action output
     """
+    assert ops_test.model
     tls_requirer_unit = ops_test.model.units[f"{VAULT_PKI_REQUIRER_APPLICATION_NAME}/0"]
+    assert isinstance(tls_requirer_unit, Unit)
     action = await tls_requirer_unit.run_action(
         action_name="get-certificate",
     )


### PR DESCRIPTION
# Description

In #87 , we added the "upstream" side of the PKI integration. Here we add the "downstream" side that TLS requirers can use to request TLS certificates. Vault will treat those requests using the PKI secrets engine. This is accomplished using the `tls-certificates` interface which we alias to `vault-pki` here to standardise with `vault-transit` and `vault-kv`.

![image](https://github.com/canonical/vault-k8s-operator/assets/18486508/b8529d32-1d77-49bd-ad21-b2085764aa9c)

## Usage

Deploy Vault

```
juju deploy vault -n 3 --config common_name=mydomain.com
```

Deploy the parent CA

```
juju deploy self-signed-certificates
```

Integrate Vault with its parent CA

```
juju integrate vault:tls-certificates-pki self-signed-certificates
```

Deploy tls-certificates-requirer

```
juju deploy tls-certificates-requirer --common_name=demo.mydomain.com
```

Integrate TLS Certificates Requirer with Vault
```
juju integrate tls-certificates-requirer vault:vault-pki
```

Retrieve the certificate
```
juju run tls-certificates-requirer/leader get-certificate
```

## Note

This implementation is (almost) identical to the one in the K8s charm introduced in this PR:
- https://github.com/canonical/vault-k8s-operator/pull/185

## Reference

- https://developer.hashicorp.com/vault/docs/secrets/pki

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
