### PR TITLE
chore: use `bug` label in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,35 +1,38 @@
 ---
 name: Bug report
-about: Create a report to help us improve
-title: "[BUG]"
-labels: ''
+about: Create a bug report to help us improve
+title: ""
+labels: ["bug"]
 assignees: ''
-
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+#### Describe the bug
+<!-- A clear and concise description of what the bug is. -->
 
-**To Reproduce**
-Steps to reproduce the behavior:
+#### To Reproduce
+<!-- Steps that can be taken to reproduce the behaviour -->
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+#### Expected behavior
+<!-- A clear and concise description of what you expected to happen. -->
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+#### Screenshots
+<!-- If applicable, add screenshots to help explain your problem. -->
 
-**Logs**
-If applicable, add logs to help explain your problem.
+#### Logs
+<!-- If applicable, add logs to help explain your problem. -->
 
-**Environment**
- - Vault version: [e.g. 1.11.2]
- - Juju version: [e.g. 2.9.23]
- - Cloud Environment [e.g. GKE]
+#### Environment
 
-**Additional context**
-Add any other context about the problem here.
+- Charm / library version (if relevant): <!-- e.g. 1.2 -->
+- Juju version (output from `juju --version`):
+- Cloud Environment: <!-- e.g. GKE -->
+- Kubernetes version (output from `kubectl version --short`):
+
+#### Additional context
+
+<!-- Add any other context about the problem here. -->


### PR DESCRIPTION
# Description

Use labels in issue template. Here I copied the template from the k8s version of the charm. 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
