### PR TITLE
feat: implement the vault-kv relation

### DIFF
--- a/lib/charms/vault_k8s/v0/vault_kv.py
+++ b/lib/charms/vault_k8s/v0/vault_kv.py
@@ -1,0 +1,596 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Library for the vault-kv relation.
+
+This library contains the Requires and Provides classes for handling the vault-kv
+interface.
+
+## Getting Started
+From a charm directory, fetch the library using `charmcraft`:
+
+```shell
+charmcraft fetch-lib charms.vault_k8s.v0.vault_kv
+```
+
+### Requirer charm
+The requirer charm is the charm requiring a secret value store. In this example, the requirer charm
+is requiring a secret value store.
+
+```python
+import secrets
+
+from charms.vault_k8s.v0 import vault_kv
+from ops.charm import CharmBase, InstallEvent
+from ops.main import main
+from ops.model import ActiveStatus, BlockedStatus
+
+NONCE_SECRET_LABEL = "nonce"
+
+
+class ExampleRequirerCharm(CharmBase):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.interface = vault_kv.VaultKvRequires(
+            self,
+            "vault-kv",
+            "my-suffix",
+        )
+
+        self.framework.observe(self.on.install, self._on_install)
+        self.framework.observe(self.interface.on.connected, self._on_connected)
+        self.framework.observe(self.interface.on.ready, self._on_ready)
+        self.framework.observe(self.interface.on.gone_away, self._on_gone_away)
+        self.framework.observe(self.on.update_status, self._on_update_status)
+
+    def _on_install(self, event: InstallEvent):
+        self.unit.add_secret(
+            {"nonce": secrets.token_hex(16)},
+            label=NONCE_SECRET_LABEL,
+            description="Nonce for vault-kv relation",
+        )
+        self.unit.status = BlockedStatus("Waiting for vault-kv relation")
+
+    def _on_connected(self, event: vault_kv.VaultKvConnectedEvent):
+        relation = self.model.get_relation(event.relation_name, event.relation_id)
+        egress_subnet = str(self.model.get_binding(relation).network.interfaces[0].subnet)
+        self.interface.request_credentials(relation, egress_subnet, self.get_nonce())
+
+    def _on_ready(self, event: vault_kv.VaultKvReadyEvent):
+        relation = self.model.get_relation(event.relation_name, event.relation_id)
+        if relation is None:
+            return
+        vault_url = self.interface.get_vault_url(relation)
+        ca_certificate = self.interface.get_ca_certificate(relation)
+        mount = self.interface.get_mount(relation)
+
+        unit_credentials = self.interface.get_unit_credentials(relation)
+        # unit_credentials is a juju secret id
+        secret = self.model.get_secret(id=unit_credentials)
+        secret_content = secret.get_content()
+        role_id = secret_content["role-id"]
+        role_secret_id = secret_content["role-secret-id"]
+
+        self._configure(vault_url, ca_certificate, mount, role_id, role_secret_id)
+
+        self.unit.status = ActiveStatus()
+
+    def _on_gone_away(self, event: vault_kv.VaultKvGoneAwayEvent):
+        self.unit.status = BlockedStatus("Waiting for vault-kv relation")
+
+    def _configure(
+        self,
+        vault_url: str,
+        ca_certificate: str,
+        mount: str,
+        role_id: str,
+        role_secret_id: str,
+    ):
+        pass
+
+    def _on_update_status(self, event):
+        # Check somewhere that egress subnet has not changed i.e. pod has not been rescheduled
+        # Update status might not be the best place
+        binding = self.model.get_binding("vault-kv")
+        if binding is not None:
+            egress_subnet = str(binding.network.interfaces[0].subnet)
+            self.interface.request_credentials(event.relation, egress_subnet, self.get_nonce())
+
+    def get_nonce(self):
+        secret = self.model.get_secret(label=NONCE_SECRET_LABEL)
+        nonce = secret.get_content()["nonce"]
+        return nonce
+
+
+if __name__ == "__main__":
+    main(ExampleRequirerCharm)
+```
+
+You can integrate both charms by running:
+
+```bash
+juju integrate <vault provider charm> <vault requirer charm>
+```
+"""
+
+import json
+import logging
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Union
+
+import ops
+from interface_tester.schema_base import DataBagSchema  # type: ignore[import-untyped]
+from pydantic import BaseModel, Field, Json, ValidationError
+
+logger = logging.getLogger(__name__)
+
+
+# The unique Charmhub library identifier, never change it
+LIBID = "591d6d2fb6a54853b4bb53ef16ef603a"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 3
+
+PYDEPS = ["pydantic", "pytest-interface-tester"]
+
+
+class VaultKvProviderSchema(BaseModel):
+    """Provider side of the vault-kv interface."""
+
+    vault_url: str = Field(description="The URL of the Vault server to connect to.")
+    mount: str = Field(
+        description=(
+            "The KV mount available for the requirer application, "
+            "respecting the pattern 'charm-<requirer app>-<user provided suffix>'."
+        )
+    )
+    ca_certificate: str = Field(
+        description="The CA certificate to use when validating the Vault server's certificate."
+    )
+    credentials: Json[Mapping[str, str]] = Field(
+        description=(
+            "Mapping of unit name and credentials for that unit."
+            " Credentials are a juju secret containing a 'role-id' and a 'role-secret-id'."
+        )
+    )
+
+
+class AppVaultKvRequirerSchema(BaseModel):
+    """App schema of the requirer side of the vault-kv interface."""
+
+    mount_suffix: str = Field(
+        description="Suffix to append to the mount name to get the KV mount."
+    )
+
+
+class UnitVaultKvRequirerSchema(BaseModel):
+    """Unit schema of the requirer side of the vault-kv interface."""
+
+    egress_subnet: str = Field(description="Egress subnet to use, in CIDR notation.")
+    nonce: str = Field(
+        description="Uniquely identifying value for this unit. `secrets.token_hex(16)` is recommended."
+    )
+
+
+class ProviderSchema(DataBagSchema):
+    """The schema for the provider side of this interface."""
+
+    app: VaultKvProviderSchema
+
+
+class RequirerSchema(DataBagSchema):
+    """The schema for the requirer side of this interface."""
+
+    app: AppVaultKvRequirerSchema
+    unit: UnitVaultKvRequirerSchema
+
+@dataclass
+class KVRequest:
+    """This class represents a kv request from an interface Requirer."""
+    relation_id: int
+    app_name: str
+    unit_name: str
+    mount_suffix: str
+    egress_subnet: str
+    nonce: str
+
+
+def is_requirer_data_valid(app_data: dict, unit_data: dict) -> bool:
+    """Return whether the requirer data is valid."""
+    try:
+        RequirerSchema(
+            app=AppVaultKvRequirerSchema(**app_data),
+            unit=UnitVaultKvRequirerSchema(**unit_data),
+        )
+        return True
+    except ValidationError as e:
+        logger.debug("Invalid data: %s", e)
+        return False
+
+
+def is_provider_data_valid(data: dict) -> bool:
+    """Return whether the provider data is valid."""
+    try:
+        ProviderSchema(app=VaultKvProviderSchema(**data))
+        return True
+    except ValidationError as e:
+        logger.debug("Invalid data: %s", e)
+        return False
+
+
+class NewVaultKvClientAttachedEvent(ops.EventBase):
+    """New vault kv client attached event."""
+
+    def __init__(
+        self,
+        handle: ops.Handle,
+        relation_id: int,
+        app_name: str,
+        unit_name: str,
+        mount_suffix: str,
+        egress_subnet: str,
+        nonce: str,
+    ):
+        super().__init__(handle)
+        self.relation_id = relation_id
+        self.app_name = app_name
+        self.unit_name = unit_name
+        self.mount_suffix = mount_suffix
+        self.egress_subnet = egress_subnet
+        self.nonce = nonce
+
+    def snapshot(self) -> dict:
+        """Return snapshot data that should be persisted."""
+        return {
+            "relation_id": self.relation_id,
+            "app_name": self.app_name,
+            "unit_name": self.unit_name,
+            "mount_suffix": self.mount_suffix,
+            "egress_subnet": self.egress_subnet,
+            "nonce": self.nonce,
+        }
+
+    def restore(self, snapshot: Dict[str, Any]):
+        """Restore the value state from a given snapshot."""
+        super().restore(snapshot)
+        self.relation_id = snapshot["relation_id"]
+        self.app_name = snapshot["app_name"]
+        self.unit_name = snapshot["unit_name"]
+        self.mount_suffix = snapshot["mount_suffix"]
+        self.egress_subnet = snapshot["egress_subnet"]
+        self.nonce = snapshot["nonce"]
+
+
+class VaultKvProviderEvents(ops.ObjectEvents):
+    """List of events that the Vault Kv provider charm can leverage."""
+
+    new_vault_kv_client_attached = ops.EventSource(NewVaultKvClientAttachedEvent)
+
+
+class VaultKvProvides(ops.Object):
+    """Class to be instanciated by the providing side of the relation."""
+
+    on = VaultKvProviderEvents()
+
+    def __init__(
+        self,
+        charm: ops.CharmBase,
+        relation_name: str,
+    ) -> None:
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.relation_name = relation_name
+        self.framework.observe(
+            self.charm.on[relation_name].relation_changed,
+            self._on_relation_changed,
+        )
+
+    def _on_relation_changed(self, event: ops.RelationChangedEvent):
+        """Handle client changed relation.
+
+        This handler will emit a new_vault_kv_client_attached event for each requiring unit
+        with valid relation data.
+        """
+        if event.app is None:
+            logger.debug("No remote application yet")
+            return
+        app_data = dict(event.relation.data[event.app])
+        for unit in event.relation.units:
+            if not is_requirer_data_valid(app_data, dict(event.relation.data[unit])):
+                logger.debug("Invalid data from unit %r", unit.name)
+                continue
+            self.on.new_vault_kv_client_attached.emit(
+                relation_id=event.relation.id,
+                app_name=event.app.name,
+                unit_name=unit.name,
+                mount_suffix=event.relation.data[event.app]["mount_suffix"],
+                egress_subnet=event.relation.data[unit]["egress_subnet"],
+                nonce=event.relation.data[unit]["nonce"],
+            )
+
+    def set_vault_url(self, relation: ops.Relation, vault_url: str):
+        """Set the vault_url on the relation."""
+        if not self.charm.unit.is_leader():
+            return
+
+        relation.data[self.charm.app]["vault_url"] = vault_url
+
+    def set_ca_certificate(self, relation: ops.Relation, ca_certificate: str):
+        """Set the ca_certificate on the relation."""
+        if not self.charm.unit.is_leader():
+            return
+
+        relation.data[self.charm.app]["ca_certificate"] = ca_certificate
+
+    def set_mount(self, relation: ops.Relation, mount: str):
+        """Set the mount on the relation."""
+        if not self.charm.unit.is_leader():
+            return
+
+        relation.data[self.charm.app]["mount"] = mount
+
+    def set_unit_credentials(self, relation: ops.Relation, nonce: str, secret: ops.Secret):
+        """Set the unit credentials on the relation."""
+        if not self.charm.unit.is_leader():
+            return
+
+        credentials = self.get_credentials(relation)
+        if secret.id is None:
+            logger.debug(
+                "Secret id is None, not updating the relation '%s:%d' for nonce %r",
+                relation.name,
+                relation.id,
+                nonce,
+            )
+            return
+        credentials[nonce] = secret.id
+        relation.data[self.charm.app]["credentials"] = json.dumps(credentials, sort_keys=True)
+
+    def remove_unit_credentials(self, relation: ops.Relation, nonce: Union[str, Iterable[str]]):
+        """Remove nonce(s) from the relation."""
+        if not self.charm.unit.is_leader():
+            return
+
+        if isinstance(nonce, str):
+            nonce = [nonce]
+
+        credentials = self.get_credentials(relation)
+
+        for n in nonce:
+            credentials.pop(n, None)
+
+        relation.data[self.charm.app]["credentials"] = json.dumps(credentials, sort_keys=True)
+
+    def get_credentials(self, relation: ops.Relation) -> dict:
+        """Get the unit credentials from the relation."""
+        return json.loads(relation.data[self.charm.app].get("credentials", "{}"))
+
+    def get_outstanding_kv_requests(self, relation_id: Optional[int] = None) -> List[KVRequest]:
+        """Get the outstanding requests for the relation."""
+        outstanding_requests: List[KVRequest] = []
+        kv_requests = self.get_kv_requests(relation_id=relation_id)
+        for request in kv_requests:
+            if not self._credentials_issued_for_request(nonce=request.nonce, relation_id=relation_id):
+                outstanding_requests.append(request)
+        return outstanding_requests
+
+    def get_kv_requests(self, relation_id: Optional[int] = None) -> List[KVRequest]:
+        """Get all KV requests for the relation."""
+        kv_requests: List[KVRequest] = []
+        relations = (
+            [
+                relation
+                for relation in self.model.relations[self.relation_name]
+                if relation.id == relation_id
+            ]
+            if relation_id is not None
+            else self.model.relations.get(self.relation_name, [])
+        )
+        for relation in relations:
+            app_data = dict(relation.data[relation.app])
+            for unit in relation.units:
+                unit_data = dict(relation.data[unit])
+                if not is_requirer_data_valid(app_data=app_data, unit_data=unit_data):
+                    continue
+                kv_requests.append(
+                    KVRequest(
+                        relation_id=relation.id,
+                        app_name=relation.app.name,
+                        unit_name=unit.name,
+                        mount_suffix=app_data["mount_suffix"],
+                        egress_subnet=unit_data["egress_subnet"],
+                        nonce=unit_data["nonce"],
+                    )
+                )
+        return kv_requests
+
+    def _credentials_issued_for_request(self, nonce: str, relation_id: int) -> bool:
+        """Return whether credentials have been issued for the request."""
+        relation = self.model.get_relation(self.relation_name, relation_id)
+        if not relation:
+            return False
+        credentials = self.get_credentials(relation)
+        return credentials.get(nonce) is not None
+
+
+class VaultKvConnectedEvent(ops.EventBase):
+    """VaultKvConnectedEvent Event."""
+
+    def __init__(
+        self,
+        handle: ops.Handle,
+        relation_id: int,
+        relation_name: str,
+    ):
+        super().__init__(handle)
+        self.relation_id = relation_id
+        self.relation_name = relation_name
+
+    def snapshot(self) -> dict:
+        """Return snapshot data that should be persisted."""
+        return {
+            "relation_id": self.relation_id,
+            "relation_name": self.relation_name,
+        }
+
+    def restore(self, snapshot: Dict[str, Any]):
+        """Restore the value state from a given snapshot."""
+        super().restore(snapshot)
+        self.relation_id = snapshot["relation_id"]
+        self.relation_name = snapshot["relation_name"]
+
+
+class VaultKvReadyEvent(ops.EventBase):
+    """VaultKvReadyEvent Event."""
+
+    def __init__(
+        self,
+        handle: ops.Handle,
+        relation_id: int,
+        relation_name: str,
+    ):
+        super().__init__(handle)
+        self.relation_id = relation_id
+        self.relation_name = relation_name
+
+    def snapshot(self) -> dict:
+        """Return snapshot data that should be persisted."""
+        return {
+            "relation_id": self.relation_id,
+            "relation_name": self.relation_name,
+        }
+
+    def restore(self, snapshot: Dict[str, Any]):
+        """Restore the value state from a given snapshot."""
+        super().restore(snapshot)
+        self.relation_id = snapshot["relation_id"]
+        self.relation_name = snapshot["relation_name"]
+
+
+class VaultKvGoneAwayEvent(ops.EventBase):
+    """VaultKvGoneAwayEvent Event."""
+
+    pass
+
+
+class VaultKvRequireEvents(ops.ObjectEvents):
+    """List of events that the Vault Kv requirer charm can leverage."""
+
+    connected = ops.EventSource(VaultKvConnectedEvent)
+    ready = ops.EventSource(VaultKvReadyEvent)
+    gone_away = ops.EventSource(VaultKvGoneAwayEvent)
+
+
+class VaultKvRequires(ops.Object):
+    """Class to be instanciated by the requiring side of the relation."""
+
+    on = VaultKvRequireEvents()
+
+    def __init__(
+        self,
+        charm: ops.CharmBase,
+        relation_name: str,
+        mount_suffix: str,
+    ) -> None:
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.relation_name = relation_name
+        self.mount_suffix = mount_suffix
+        self.framework.observe(
+            self.charm.on[relation_name].relation_joined,
+            self._on_vault_kv_relation_joined,
+        )
+        self.framework.observe(
+            self.charm.on[relation_name].relation_changed,
+            self._on_vault_kv_relation_changed,
+        )
+        self.framework.observe(
+            self.charm.on[relation_name].relation_broken,
+            self._on_vault_kv_relation_broken,
+        )
+
+    def _set_unit_nonce(self, relation: ops.Relation, nonce: str):
+        """Set the nonce on the relation."""
+        relation.data[self.charm.unit]["nonce"] = nonce
+
+    def _set_unit_egress_subnet(self, relation: ops.Relation, egress_subnet: str):
+        """Set the egress_subnet on the relation."""
+        relation.data[self.charm.unit]["egress_subnet"] = egress_subnet
+
+    def _on_vault_kv_relation_joined(self, event: ops.RelationJoinedEvent):
+        """Handle relation joined.
+
+        Set the secret backend in the application databag if we are the leader.
+        Always update the egress_subnet in the unit databag.
+        """
+        if self.charm.unit.is_leader():
+            event.relation.data[self.charm.app]["mount_suffix"] = self.mount_suffix
+        self.on.connected.emit(
+            event.relation.id,
+            event.relation.name,
+        )
+
+    def _on_vault_kv_relation_changed(self, event: ops.RelationChangedEvent):
+        """Handle relation changed."""
+        if event.app is None:
+            logger.debug("No remote application yet")
+            return
+
+        if (
+            is_provider_data_valid(dict(event.relation.data[event.app]))
+            and self.get_unit_credentials(event.relation) is not None
+        ):
+            self.on.ready.emit(
+                event.relation.id,
+                event.relation.name,
+            )
+
+    def _on_vault_kv_relation_broken(self, event: ops.RelationBrokenEvent):
+        """Handle relation broken."""
+        self.on.gone_away.emit()
+
+    def request_credentials(self, relation: ops.Relation, egress_subnet: str, nonce: str) -> None:
+        """Request credentials from the vault-kv relation.
+
+        Generated secret ids are tied to the unit egress_subnet, so if the egress_subnet
+        changes a new secret id must be generated.
+
+        A change in egress_subnet can happen when the pod is rescheduled to a different
+        node by the underlying substrate without a change from Juju.
+        """
+        self._set_unit_egress_subnet(relation, egress_subnet)
+        self._set_unit_nonce(relation, nonce)
+
+    def get_vault_url(self, relation: ops.Relation) -> Optional[str]:
+        """Return the vault_url from the relation."""
+        if relation.app is None:
+            return None
+        return relation.data[relation.app].get("vault_url")
+
+    def get_ca_certificate(self, relation: ops.Relation) -> Optional[str]:
+        """Return the ca_certificate from the relation."""
+        if relation.app is None:
+            return None
+        return relation.data[relation.app].get("ca_certificate")
+
+    def get_mount(self, relation: ops.Relation) -> Optional[str]:
+        """Return the mount from the relation."""
+        if relation.app is None:
+            return None
+        return relation.data[relation.app].get("mount")
+
+    def get_unit_credentials(self, relation: ops.Relation) -> Optional[str]:
+        """Return the unit credentials from the relation.
+
+        Unit credentials are stored in the relation data as a Juju secret id.
+        """
+        nonce = relation.data[self.charm.unit].get("nonce")
+        if nonce is None or relation.app is None:
+            return None
+        return json.loads(relation.data[relation.app].get("credentials", "{}")).get(nonce)

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -36,6 +36,8 @@ peers:
     interface: vault-peer
 
 provides:
+  vault-kv:
+    interface: vault-kv
   vault-pki:
     interface: tls-certificates
   cos-agent:

--- a/requirements.in
+++ b/requirements.in
@@ -5,6 +5,7 @@ jsonschema
 ops
 psutil
 pyhcl
+pytest-interface-tester
 # cos-agent requires pydantic<2
 pydantic<2
 # vault_client requirements

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,8 @@ cffi==1.16.0
     # via cryptography
 charset-normalizer==3.3.2
     # via requests
+click==8.1.7
+    # via typer
 cosl==0.0.10
     # via -r requirements.in
 cryptography==42.0.5
@@ -22,6 +24,8 @@ hvac==2.1.0
     # via -r requirements.in
 idna==3.6
     # via requests
+iniconfig==2.0.0
+    # via pytest
 jinja2==3.1.3
     # via -r requirements.in
 jsonschema==4.21.1
@@ -34,19 +38,33 @@ ops==2.11.0
     # via
     #   -r requirements.in
     #   cosl
+    #   ops-scenario
+ops-scenario==6.0.3
+    # via pytest-interface-tester
+packaging==24.0
+    # via pytest
+pluggy==1.4.0
+    # via pytest
 psutil==5.9.8
     # via -r requirements.in
 pycparser==2.21
     # via cffi
 pydantic==1.10.14
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   pytest-interface-tester
 pyhcl==0.4.5
+    # via -r requirements.in
+pytest==8.1.1
+    # via pytest-interface-tester
+pytest-interface-tester==2.0.1
     # via -r requirements.in
 pyyaml==6.0.1
     # via
     #   cosl
     #   ops
-referencing==0.33.0
+    #   ops-scenario
+referencing==0.34.0
     # via
     #   jsonschema
     #   jsonschema-specifications
@@ -56,7 +74,9 @@ rpds-py==0.18.0
     # via
     #   jsonschema
     #   referencing
-typing-extensions==4.9.0
+typer==0.7.0
+    # via pytest-interface-tester
+typing-extensions==4.10.0
     # via
     #   cosl
     #   pydantic

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -12,34 +12,46 @@ cachetools==5.3.3
     # via google-auth
 certifi==2024.2.2
     # via
+    #   -c requirements.txt
     #   kubernetes
     #   requests
 cffi==1.16.0
     # via
+    #   -c requirements.txt
     #   cryptography
     #   pynacl
 charset-normalizer==3.3.2
-    # via requests
+    # via
+    #   -c requirements.txt
+    #   requests
 codespell==2.2.6
     # via -r test-requirements.in
 coverage[toml]==7.4.4
     # via -r test-requirements.in
 cryptography==42.0.5
-    # via paramiko
+    # via
+    #   -c requirements.txt
+    #   paramiko
 decorator==5.1.1
     # via
     #   ipdb
     #   ipython
 executing==2.0.1
     # via stack-data
-google-auth==2.28.1
+google-auth==2.29.0
     # via kubernetes
 hvac==2.1.0
-    # via juju
+    # via
+    #   -c requirements.txt
+    #   juju
 idna==3.6
-    # via requests
+    # via
+    #   -c requirements.txt
+    #   requests
 iniconfig==2.0.0
-    # via pytest
+    # via
+    #   -c requirements.txt
+    #   pytest
 ipdb==0.13.13
     # via pytest-operator
 ipython==8.22.2
@@ -47,7 +59,9 @@ ipython==8.22.2
 jedi==0.19.1
     # via ipython
 jinja2==3.1.3
-    # via pytest-operator
+    # via
+    #   -c requirements.txt
+    #   pytest-operator
 juju==3.3.1.1
     # via
     #   -r test-requirements.in
@@ -57,7 +71,9 @@ kubernetes==29.0.0
 macaroonbakery==1.3.4
     # via juju
 markupsafe==2.1.5
-    # via jinja2
+    # via
+    #   -c requirements.txt
+    #   jinja2
 matplotlib-inline==0.1.6
     # via ipython
 mypy-extensions==1.0.0
@@ -68,8 +84,9 @@ oauthlib==3.2.2
     # via
     #   kubernetes
     #   requests-oauthlib
-packaging==23.2
+packaging==24.0
     # via
+    #   -c requirements.txt
     #   juju
     #   pytest
 paramiko==3.4.0
@@ -79,10 +96,12 @@ parso==0.8.3
 pexpect==4.9.0
     # via ipython
 pluggy==1.4.0
-    # via pytest
+    # via
+    #   -c requirements.txt
+    #   pytest
 prompt-toolkit==3.0.43
     # via ipython
-protobuf==4.25.3
+protobuf==5.26.0
     # via macaroonbakery
 ptyprocess==0.7.0
     # via pexpect
@@ -96,7 +115,9 @@ pyasn1==0.5.1
 pyasn1-modules==0.3.0
     # via google-auth
 pycparser==2.21
-    # via cffi
+    # via
+    #   -c requirements.txt
+    #   cffi
 pygments==2.17.2
     # via ipython
 pymacaroons==0.13.0
@@ -114,6 +135,7 @@ pyright==1.1.355
     # via -r test-requirements.in
 pytest==8.1.1
     # via
+    #   -c requirements.txt
     #   -r test-requirements.in
     #   pytest-asyncio
     #   pytest-operator
@@ -127,16 +149,18 @@ pytz==2024.1
     # via pyrfc3339
 pyyaml==6.0.1
     # via
+    #   -c requirements.txt
     #   juju
     #   kubernetes
     #   pytest-operator
 requests==2.31.0
     # via
+    #   -c requirements.txt
     #   hvac
     #   kubernetes
     #   macaroonbakery
     #   requests-oauthlib
-requests-oauthlib==1.3.1
+requests-oauthlib==2.0.0
     # via kubernetes
 rsa==4.9
     # via google-auth
@@ -153,22 +177,27 @@ stack-data==0.6.3
     # via ipython
 toposort==1.10
     # via juju
-traitlets==5.14.1
+traitlets==5.14.2
     # via
     #   ipython
     #   matplotlib-inline
-typing-extensions==4.9.0
-    # via typing-inspect
+typing-extensions==4.10.0
+    # via
+    #   -c requirements.txt
+    #   typing-inspect
 typing-inspect==0.9.0
     # via juju
 urllib3==2.2.1
     # via
+    #   -c requirements.txt
     #   kubernetes
     #   requests
 wcwidth==0.2.13
     # via prompt-toolkit
 websocket-client==1.7.0
-    # via kubernetes
+    # via
+    #   -c requirements.txt
+    #   kubernetes
 websockets==12.0
     # via juju
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -2,9 +2,9 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-
 import asyncio
 import logging
+import shutil
 import time
 from os.path import abspath
 from pathlib import Path
@@ -24,8 +24,12 @@ APP_NAME = METADATA["name"]
 GRAFANA_AGENT_APPLICATION_NAME = "grafana-agent"
 PEER_RELATION_NAME = "vault-peers"
 SELF_SIGNED_CERTIFICATES_APPLICATION_NAME = "self-signed-certificates"
+VAULT_KV_REQUIRER_APPLICATION_NAME = "vault-kv-requirer"
 VAULT_PKI_REQUIRER_APPLICATION_NAME = "tls-certificates-requirer"
 NUM_VAULT_UNITS = 3
+
+VAULT_KV_LIB_DIR = "lib/charms/vault_k8s/v0/vault_kv.py"
+VAULT_KV_REQUIRER_CHARM_DIR = "tests/integration/vault_kv_requirer_operator"
 
 # Vault status codes, see
 # https://developer.hashicorp.com/vault/api-docs/system/health for more details
@@ -109,26 +113,35 @@ async def wait_for_certificate_to_be_provided(ops_test: OpsTest) -> None:
     raise TimeoutError("Timed out waiting for certificate to be provided.")
 
 @pytest.fixture(scope="module")
-async def build_and_deploy(ops_test: OpsTest):
+async def build_and_deploy(ops_test: OpsTest) -> dict[str, Path | str]:
     """Build the charm-under-test and deploy it."""
     assert ops_test.model
-    charm = await ops_test.build_charm(".")
+    copy_lib_content()
+    built_charms = await ops_test.build_charms(".", f"{VAULT_KV_REQUIRER_CHARM_DIR}/")
+    vault_charm = built_charms.get(APP_NAME, "")
+    vault_kv_requirer_charm = built_charms.get("vault-kv-requirer", "")
     await ops_test.model.deploy(
-        charm,
+        vault_charm,
         application_name=APP_NAME,
         trust=True,
         num_units=NUM_VAULT_UNITS,
         config={"common_name": "example.com"},
     )
+    return {"vault-kv-requirer": vault_kv_requirer_charm}
 
 @pytest.fixture(scope="module")
-async def deploy_requiring_charms(ops_test: OpsTest, build_and_deploy: None):
+async def deploy_requiring_charms(ops_test: OpsTest, build_and_deploy: dict[str, Path | str]):
     assert ops_test.model
     deploy_self_signed_certificates = ops_test.model.deploy(
         SELF_SIGNED_CERTIFICATES_APPLICATION_NAME,
         application_name=SELF_SIGNED_CERTIFICATES_APPLICATION_NAME,
         num_units=1,
         channel="stable",
+    )
+    deploy_vault_kv_requirer = ops_test.model.deploy(
+        build_and_deploy.get("vault-kv-requirer", ""),
+        application_name=VAULT_KV_REQUIRER_APPLICATION_NAME,
+        num_units=1,
     )
     deploy_vault_pki_requirer = ops_test.model.deploy(
         VAULT_PKI_REQUIRER_APPLICATION_NAME,
@@ -145,11 +158,13 @@ async def deploy_requiring_charms(ops_test: OpsTest, build_and_deploy: None):
     )
     deployed_apps = [
         SELF_SIGNED_CERTIFICATES_APPLICATION_NAME,
+        VAULT_KV_REQUIRER_APPLICATION_NAME,
         VAULT_PKI_REQUIRER_APPLICATION_NAME,
         GRAFANA_AGENT_APPLICATION_NAME,
     ]
     await asyncio.gather(
         deploy_self_signed_certificates,
+        deploy_vault_kv_requirer,
         deploy_vault_pki_requirer,
         deploy_grafana_agent
     )
@@ -307,6 +322,20 @@ async def test_given_grafana_agent_deployed_when_relate_to_grafana_agent_then_st
             timeout=1000,
         )
 
+@pytest.mark.abort_on_fail
+async def test_given_vault_kv_requirer_deployed_when_vault_kv_relation_created_then_status_is_active(
+    self, ops_test: OpsTest, deploy_requiring_charms: None
+):
+    assert ops_test.model
+    await ops_test.model.integrate(
+        relation1=f"{APP_NAME}:vault-kv",
+        relation2=f"{VAULT_KV_REQUIRER_APPLICATION_NAME}:vault-kv",
+    )
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME, VAULT_KV_REQUIRER_APPLICATION_NAME],
+        status="active",
+        timeout=1000,
+    )
 
 @pytest.mark.abort_on_fail
 async def test_given_tls_certificates_pki_relation_when_integrate_then_status_is_active(
@@ -342,3 +371,6 @@ async def test_given_vault_pki_relation_when_integrate_then_cert_is_provided(
     assert action_output.get("certificate", None) is not None
     assert action_output.get("ca-certificate", None) is not None
     assert action_output.get("csr", None) is not None
+
+def copy_lib_content() -> None:
+    shutil.copyfile(src=VAULT_KV_LIB_DIR, dst=f"{VAULT_KV_REQUIRER_CHARM_DIR}/{VAULT_KV_LIB_DIR}")

--- a/tests/integration/vault_kv_requirer_operator/actions.yaml
+++ b/tests/integration/vault_kv_requirer_operator/actions.yaml
@@ -1,0 +1,21 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+create-secret:
+  description: Creates a secret in Vault
+  params:
+    key:
+      description: The key to create
+      type: string
+    value:
+      description: The value to create
+      type: string
+  required: [key, value]
+
+get-secret:
+  description: Gets a secret from Vault
+  params:
+    key:
+      description: The key to get
+      type: string
+  required: [key]

--- a/tests/integration/vault_kv_requirer_operator/charmcraft.yaml
+++ b/tests/integration/vault_kv_requirer_operator/charmcraft.yaml
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+type: "charm"
+bases:
+  - build-on:
+    - name: "ubuntu"
+      channel: "22.04"
+    run-on:
+    - name: "ubuntu"
+      channel: "22.04"
+
+parts:
+  charm:
+    charm-binary-python-packages:
+      - pydantic

--- a/tests/integration/vault_kv_requirer_operator/lib/charms/vault_k8s/v0/vault_kv.py
+++ b/tests/integration/vault_kv_requirer_operator/lib/charms/vault_k8s/v0/vault_kv.py
@@ -1,0 +1,596 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Library for the vault-kv relation.
+
+This library contains the Requires and Provides classes for handling the vault-kv
+interface.
+
+## Getting Started
+From a charm directory, fetch the library using `charmcraft`:
+
+```shell
+charmcraft fetch-lib charms.vault_k8s.v0.vault_kv
+```
+
+### Requirer charm
+The requirer charm is the charm requiring a secret value store. In this example, the requirer charm
+is requiring a secret value store.
+
+```python
+import secrets
+
+from charms.vault_k8s.v0 import vault_kv
+from ops.charm import CharmBase, InstallEvent
+from ops.main import main
+from ops.model import ActiveStatus, BlockedStatus
+
+NONCE_SECRET_LABEL = "nonce"
+
+
+class ExampleRequirerCharm(CharmBase):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.interface = vault_kv.VaultKvRequires(
+            self,
+            "vault-kv",
+            "my-suffix",
+        )
+
+        self.framework.observe(self.on.install, self._on_install)
+        self.framework.observe(self.interface.on.connected, self._on_connected)
+        self.framework.observe(self.interface.on.ready, self._on_ready)
+        self.framework.observe(self.interface.on.gone_away, self._on_gone_away)
+        self.framework.observe(self.on.update_status, self._on_update_status)
+
+    def _on_install(self, event: InstallEvent):
+        self.unit.add_secret(
+            {"nonce": secrets.token_hex(16)},
+            label=NONCE_SECRET_LABEL,
+            description="Nonce for vault-kv relation",
+        )
+        self.unit.status = BlockedStatus("Waiting for vault-kv relation")
+
+    def _on_connected(self, event: vault_kv.VaultKvConnectedEvent):
+        relation = self.model.get_relation(event.relation_name, event.relation_id)
+        egress_subnet = str(self.model.get_binding(relation).network.interfaces[0].subnet)
+        self.interface.request_credentials(relation, egress_subnet, self.get_nonce())
+
+    def _on_ready(self, event: vault_kv.VaultKvReadyEvent):
+        relation = self.model.get_relation(event.relation_name, event.relation_id)
+        if relation is None:
+            return
+        vault_url = self.interface.get_vault_url(relation)
+        ca_certificate = self.interface.get_ca_certificate(relation)
+        mount = self.interface.get_mount(relation)
+
+        unit_credentials = self.interface.get_unit_credentials(relation)
+        # unit_credentials is a juju secret id
+        secret = self.model.get_secret(id=unit_credentials)
+        secret_content = secret.get_content()
+        role_id = secret_content["role-id"]
+        role_secret_id = secret_content["role-secret-id"]
+
+        self._configure(vault_url, ca_certificate, mount, role_id, role_secret_id)
+
+        self.unit.status = ActiveStatus()
+
+    def _on_gone_away(self, event: vault_kv.VaultKvGoneAwayEvent):
+        self.unit.status = BlockedStatus("Waiting for vault-kv relation")
+
+    def _configure(
+        self,
+        vault_url: str,
+        ca_certificate: str,
+        mount: str,
+        role_id: str,
+        role_secret_id: str,
+    ):
+        pass
+
+    def _on_update_status(self, event):
+        # Check somewhere that egress subnet has not changed i.e. pod has not been rescheduled
+        # Update status might not be the best place
+        binding = self.model.get_binding("vault-kv")
+        if binding is not None:
+            egress_subnet = str(binding.network.interfaces[0].subnet)
+            self.interface.request_credentials(event.relation, egress_subnet, self.get_nonce())
+
+    def get_nonce(self):
+        secret = self.model.get_secret(label=NONCE_SECRET_LABEL)
+        nonce = secret.get_content()["nonce"]
+        return nonce
+
+
+if __name__ == "__main__":
+    main(ExampleRequirerCharm)
+```
+
+You can integrate both charms by running:
+
+```bash
+juju integrate <vault provider charm> <vault requirer charm>
+```
+"""
+
+import json
+import logging
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Union
+
+import ops
+from interface_tester.schema_base import DataBagSchema  # type: ignore[import-untyped]
+from pydantic import BaseModel, Field, Json, ValidationError
+
+logger = logging.getLogger(__name__)
+
+
+# The unique Charmhub library identifier, never change it
+LIBID = "591d6d2fb6a54853b4bb53ef16ef603a"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 3
+
+PYDEPS = ["pydantic", "pytest-interface-tester"]
+
+
+class VaultKvProviderSchema(BaseModel):
+    """Provider side of the vault-kv interface."""
+
+    vault_url: str = Field(description="The URL of the Vault server to connect to.")
+    mount: str = Field(
+        description=(
+            "The KV mount available for the requirer application, "
+            "respecting the pattern 'charm-<requirer app>-<user provided suffix>'."
+        )
+    )
+    ca_certificate: str = Field(
+        description="The CA certificate to use when validating the Vault server's certificate."
+    )
+    credentials: Json[Mapping[str, str]] = Field(
+        description=(
+            "Mapping of unit name and credentials for that unit."
+            " Credentials are a juju secret containing a 'role-id' and a 'role-secret-id'."
+        )
+    )
+
+
+class AppVaultKvRequirerSchema(BaseModel):
+    """App schema of the requirer side of the vault-kv interface."""
+
+    mount_suffix: str = Field(
+        description="Suffix to append to the mount name to get the KV mount."
+    )
+
+
+class UnitVaultKvRequirerSchema(BaseModel):
+    """Unit schema of the requirer side of the vault-kv interface."""
+
+    egress_subnet: str = Field(description="Egress subnet to use, in CIDR notation.")
+    nonce: str = Field(
+        description="Uniquely identifying value for this unit. `secrets.token_hex(16)` is recommended."
+    )
+
+
+class ProviderSchema(DataBagSchema):
+    """The schema for the provider side of this interface."""
+
+    app: VaultKvProviderSchema
+
+
+class RequirerSchema(DataBagSchema):
+    """The schema for the requirer side of this interface."""
+
+    app: AppVaultKvRequirerSchema
+    unit: UnitVaultKvRequirerSchema
+
+@dataclass
+class KVRequest:
+    """This class represents a kv request from an interface Requirer."""
+    relation_id: int
+    app_name: str
+    unit_name: str
+    mount_suffix: str
+    egress_subnet: str
+    nonce: str
+
+
+def is_requirer_data_valid(app_data: dict, unit_data: dict) -> bool:
+    """Return whether the requirer data is valid."""
+    try:
+        RequirerSchema(
+            app=AppVaultKvRequirerSchema(**app_data),
+            unit=UnitVaultKvRequirerSchema(**unit_data),
+        )
+        return True
+    except ValidationError as e:
+        logger.debug("Invalid data: %s", e)
+        return False
+
+
+def is_provider_data_valid(data: dict) -> bool:
+    """Return whether the provider data is valid."""
+    try:
+        ProviderSchema(app=VaultKvProviderSchema(**data))
+        return True
+    except ValidationError as e:
+        logger.debug("Invalid data: %s", e)
+        return False
+
+
+class NewVaultKvClientAttachedEvent(ops.EventBase):
+    """New vault kv client attached event."""
+
+    def __init__(
+        self,
+        handle: ops.Handle,
+        relation_id: int,
+        app_name: str,
+        unit_name: str,
+        mount_suffix: str,
+        egress_subnet: str,
+        nonce: str,
+    ):
+        super().__init__(handle)
+        self.relation_id = relation_id
+        self.app_name = app_name
+        self.unit_name = unit_name
+        self.mount_suffix = mount_suffix
+        self.egress_subnet = egress_subnet
+        self.nonce = nonce
+
+    def snapshot(self) -> dict:
+        """Return snapshot data that should be persisted."""
+        return {
+            "relation_id": self.relation_id,
+            "app_name": self.app_name,
+            "unit_name": self.unit_name,
+            "mount_suffix": self.mount_suffix,
+            "egress_subnet": self.egress_subnet,
+            "nonce": self.nonce,
+        }
+
+    def restore(self, snapshot: Dict[str, Any]):
+        """Restore the value state from a given snapshot."""
+        super().restore(snapshot)
+        self.relation_id = snapshot["relation_id"]
+        self.app_name = snapshot["app_name"]
+        self.unit_name = snapshot["unit_name"]
+        self.mount_suffix = snapshot["mount_suffix"]
+        self.egress_subnet = snapshot["egress_subnet"]
+        self.nonce = snapshot["nonce"]
+
+
+class VaultKvProviderEvents(ops.ObjectEvents):
+    """List of events that the Vault Kv provider charm can leverage."""
+
+    new_vault_kv_client_attached = ops.EventSource(NewVaultKvClientAttachedEvent)
+
+
+class VaultKvProvides(ops.Object):
+    """Class to be instanciated by the providing side of the relation."""
+
+    on = VaultKvProviderEvents()
+
+    def __init__(
+        self,
+        charm: ops.CharmBase,
+        relation_name: str,
+    ) -> None:
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.relation_name = relation_name
+        self.framework.observe(
+            self.charm.on[relation_name].relation_changed,
+            self._on_relation_changed,
+        )
+
+    def _on_relation_changed(self, event: ops.RelationChangedEvent):
+        """Handle client changed relation.
+
+        This handler will emit a new_vault_kv_client_attached event for each requiring unit
+        with valid relation data.
+        """
+        if event.app is None:
+            logger.debug("No remote application yet")
+            return
+        app_data = dict(event.relation.data[event.app])
+        for unit in event.relation.units:
+            if not is_requirer_data_valid(app_data, dict(event.relation.data[unit])):
+                logger.debug("Invalid data from unit %r", unit.name)
+                continue
+            self.on.new_vault_kv_client_attached.emit(
+                relation_id=event.relation.id,
+                app_name=event.app.name,
+                unit_name=unit.name,
+                mount_suffix=event.relation.data[event.app]["mount_suffix"],
+                egress_subnet=event.relation.data[unit]["egress_subnet"],
+                nonce=event.relation.data[unit]["nonce"],
+            )
+
+    def set_vault_url(self, relation: ops.Relation, vault_url: str):
+        """Set the vault_url on the relation."""
+        if not self.charm.unit.is_leader():
+            return
+
+        relation.data[self.charm.app]["vault_url"] = vault_url
+
+    def set_ca_certificate(self, relation: ops.Relation, ca_certificate: str):
+        """Set the ca_certificate on the relation."""
+        if not self.charm.unit.is_leader():
+            return
+
+        relation.data[self.charm.app]["ca_certificate"] = ca_certificate
+
+    def set_mount(self, relation: ops.Relation, mount: str):
+        """Set the mount on the relation."""
+        if not self.charm.unit.is_leader():
+            return
+
+        relation.data[self.charm.app]["mount"] = mount
+
+    def set_unit_credentials(self, relation: ops.Relation, nonce: str, secret: ops.Secret):
+        """Set the unit credentials on the relation."""
+        if not self.charm.unit.is_leader():
+            return
+
+        credentials = self.get_credentials(relation)
+        if secret.id is None:
+            logger.debug(
+                "Secret id is None, not updating the relation '%s:%d' for nonce %r",
+                relation.name,
+                relation.id,
+                nonce,
+            )
+            return
+        credentials[nonce] = secret.id
+        relation.data[self.charm.app]["credentials"] = json.dumps(credentials, sort_keys=True)
+
+    def remove_unit_credentials(self, relation: ops.Relation, nonce: Union[str, Iterable[str]]):
+        """Remove nonce(s) from the relation."""
+        if not self.charm.unit.is_leader():
+            return
+
+        if isinstance(nonce, str):
+            nonce = [nonce]
+
+        credentials = self.get_credentials(relation)
+
+        for n in nonce:
+            credentials.pop(n, None)
+
+        relation.data[self.charm.app]["credentials"] = json.dumps(credentials, sort_keys=True)
+
+    def get_credentials(self, relation: ops.Relation) -> dict:
+        """Get the unit credentials from the relation."""
+        return json.loads(relation.data[self.charm.app].get("credentials", "{}"))
+
+    def get_outstanding_kv_requests(self, relation_id: Optional[int] = None) -> List[KVRequest]:
+        """Get the outstanding requests for the relation."""
+        outstanding_requests: List[KVRequest] = []
+        kv_requests = self.get_kv_requests(relation_id=relation_id)
+        for request in kv_requests:
+            if not self._credentials_issued_for_request(nonce=request.nonce, relation_id=relation_id):
+                outstanding_requests.append(request)
+        return outstanding_requests
+
+    def get_kv_requests(self, relation_id: Optional[int] = None) -> List[KVRequest]:
+        """Get all KV requests for the relation."""
+        kv_requests: List[KVRequest] = []
+        relations = (
+            [
+                relation
+                for relation in self.model.relations[self.relation_name]
+                if relation.id == relation_id
+            ]
+            if relation_id is not None
+            else self.model.relations.get(self.relation_name, [])
+        )
+        for relation in relations:
+            app_data = dict(relation.data[relation.app])
+            for unit in relation.units:
+                unit_data = dict(relation.data[unit])
+                if not is_requirer_data_valid(app_data=app_data, unit_data=unit_data):
+                    continue
+                kv_requests.append(
+                    KVRequest(
+                        relation_id=relation.id,
+                        app_name=relation.app.name,
+                        unit_name=unit.name,
+                        mount_suffix=app_data["mount_suffix"],
+                        egress_subnet=unit_data["egress_subnet"],
+                        nonce=unit_data["nonce"],
+                    )
+                )
+        return kv_requests
+
+    def _credentials_issued_for_request(self, nonce: str, relation_id: int) -> bool:
+        """Return whether credentials have been issued for the request."""
+        relation = self.model.get_relation(self.relation_name, relation_id)
+        if not relation:
+            return False
+        credentials = self.get_credentials(relation)
+        return credentials.get(nonce) is not None
+
+
+class VaultKvConnectedEvent(ops.EventBase):
+    """VaultKvConnectedEvent Event."""
+
+    def __init__(
+        self,
+        handle: ops.Handle,
+        relation_id: int,
+        relation_name: str,
+    ):
+        super().__init__(handle)
+        self.relation_id = relation_id
+        self.relation_name = relation_name
+
+    def snapshot(self) -> dict:
+        """Return snapshot data that should be persisted."""
+        return {
+            "relation_id": self.relation_id,
+            "relation_name": self.relation_name,
+        }
+
+    def restore(self, snapshot: Dict[str, Any]):
+        """Restore the value state from a given snapshot."""
+        super().restore(snapshot)
+        self.relation_id = snapshot["relation_id"]
+        self.relation_name = snapshot["relation_name"]
+
+
+class VaultKvReadyEvent(ops.EventBase):
+    """VaultKvReadyEvent Event."""
+
+    def __init__(
+        self,
+        handle: ops.Handle,
+        relation_id: int,
+        relation_name: str,
+    ):
+        super().__init__(handle)
+        self.relation_id = relation_id
+        self.relation_name = relation_name
+
+    def snapshot(self) -> dict:
+        """Return snapshot data that should be persisted."""
+        return {
+            "relation_id": self.relation_id,
+            "relation_name": self.relation_name,
+        }
+
+    def restore(self, snapshot: Dict[str, Any]):
+        """Restore the value state from a given snapshot."""
+        super().restore(snapshot)
+        self.relation_id = snapshot["relation_id"]
+        self.relation_name = snapshot["relation_name"]
+
+
+class VaultKvGoneAwayEvent(ops.EventBase):
+    """VaultKvGoneAwayEvent Event."""
+
+    pass
+
+
+class VaultKvRequireEvents(ops.ObjectEvents):
+    """List of events that the Vault Kv requirer charm can leverage."""
+
+    connected = ops.EventSource(VaultKvConnectedEvent)
+    ready = ops.EventSource(VaultKvReadyEvent)
+    gone_away = ops.EventSource(VaultKvGoneAwayEvent)
+
+
+class VaultKvRequires(ops.Object):
+    """Class to be instanciated by the requiring side of the relation."""
+
+    on = VaultKvRequireEvents()
+
+    def __init__(
+        self,
+        charm: ops.CharmBase,
+        relation_name: str,
+        mount_suffix: str,
+    ) -> None:
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.relation_name = relation_name
+        self.mount_suffix = mount_suffix
+        self.framework.observe(
+            self.charm.on[relation_name].relation_joined,
+            self._on_vault_kv_relation_joined,
+        )
+        self.framework.observe(
+            self.charm.on[relation_name].relation_changed,
+            self._on_vault_kv_relation_changed,
+        )
+        self.framework.observe(
+            self.charm.on[relation_name].relation_broken,
+            self._on_vault_kv_relation_broken,
+        )
+
+    def _set_unit_nonce(self, relation: ops.Relation, nonce: str):
+        """Set the nonce on the relation."""
+        relation.data[self.charm.unit]["nonce"] = nonce
+
+    def _set_unit_egress_subnet(self, relation: ops.Relation, egress_subnet: str):
+        """Set the egress_subnet on the relation."""
+        relation.data[self.charm.unit]["egress_subnet"] = egress_subnet
+
+    def _on_vault_kv_relation_joined(self, event: ops.RelationJoinedEvent):
+        """Handle relation joined.
+
+        Set the secret backend in the application databag if we are the leader.
+        Always update the egress_subnet in the unit databag.
+        """
+        if self.charm.unit.is_leader():
+            event.relation.data[self.charm.app]["mount_suffix"] = self.mount_suffix
+        self.on.connected.emit(
+            event.relation.id,
+            event.relation.name,
+        )
+
+    def _on_vault_kv_relation_changed(self, event: ops.RelationChangedEvent):
+        """Handle relation changed."""
+        if event.app is None:
+            logger.debug("No remote application yet")
+            return
+
+        if (
+            is_provider_data_valid(dict(event.relation.data[event.app]))
+            and self.get_unit_credentials(event.relation) is not None
+        ):
+            self.on.ready.emit(
+                event.relation.id,
+                event.relation.name,
+            )
+
+    def _on_vault_kv_relation_broken(self, event: ops.RelationBrokenEvent):
+        """Handle relation broken."""
+        self.on.gone_away.emit()
+
+    def request_credentials(self, relation: ops.Relation, egress_subnet: str, nonce: str) -> None:
+        """Request credentials from the vault-kv relation.
+
+        Generated secret ids are tied to the unit egress_subnet, so if the egress_subnet
+        changes a new secret id must be generated.
+
+        A change in egress_subnet can happen when the pod is rescheduled to a different
+        node by the underlying substrate without a change from Juju.
+        """
+        self._set_unit_egress_subnet(relation, egress_subnet)
+        self._set_unit_nonce(relation, nonce)
+
+    def get_vault_url(self, relation: ops.Relation) -> Optional[str]:
+        """Return the vault_url from the relation."""
+        if relation.app is None:
+            return None
+        return relation.data[relation.app].get("vault_url")
+
+    def get_ca_certificate(self, relation: ops.Relation) -> Optional[str]:
+        """Return the ca_certificate from the relation."""
+        if relation.app is None:
+            return None
+        return relation.data[relation.app].get("ca_certificate")
+
+    def get_mount(self, relation: ops.Relation) -> Optional[str]:
+        """Return the mount from the relation."""
+        if relation.app is None:
+            return None
+        return relation.data[relation.app].get("mount")
+
+    def get_unit_credentials(self, relation: ops.Relation) -> Optional[str]:
+        """Return the unit credentials from the relation.
+
+        Unit credentials are stored in the relation data as a Juju secret id.
+        """
+        nonce = relation.data[self.charm.unit].get("nonce")
+        if nonce is None or relation.app is None:
+            return None
+        return json.loads(relation.data[relation.app].get("credentials", "{}")).get(nonce)

--- a/tests/integration/vault_kv_requirer_operator/metadata.yaml
+++ b/tests/integration/vault_kv_requirer_operator/metadata.yaml
@@ -1,0 +1,22 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+name: vault-kv-requirer
+
+display-name: Vault KV Requirer
+summary: Vault KV Requirer
+description: Vault KV Requirer
+
+assumes:
+  - juju >= 3.1
+  - k8s-api
+
+requires:
+  vault-kv:
+    interface: vault-kv
+    limit: 1
+
+storage:
+  certs:
+    type: filesystem
+    minimum-size: 5M

--- a/tests/integration/vault_kv_requirer_operator/requirements.txt
+++ b/tests/integration/vault_kv_requirer_operator/requirements.txt
@@ -1,0 +1,4 @@
+ops~=2.8.0
+hvac
+pydantic
+pytest-interface-tester

--- a/tests/integration/vault_kv_requirer_operator/src/charm.py
+++ b/tests/integration/vault_kv_requirer_operator/src/charm.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+import secrets
+from pathlib import Path
+from typing import Optional
+
+from charms.vault_k8s.v0.vault_kv import (
+    VaultKvConnectedEvent,
+    VaultKvReadyEvent,
+    VaultKvRequires,
+)
+from ops.charm import ActionEvent, CharmBase, InstallEvent
+from ops.main import main
+from ops.model import ActiveStatus, SecretNotFoundError
+from vault_client import Vault  # type: ignore[import-not-found]
+
+NONCE_SECRET_LABEL = "vault-kv-nonce"
+VAULT_KV_SECRET_LABEL = "vault-kv"
+VAULT_KV_SECRET_PATH = "test"
+VAULT_CA_CERT_FILENAME = "ca.pem"
+
+
+logger = logging.getLogger(__name__)
+
+
+class VaultKVRequirerCharm(CharmBase):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.vault_kv = VaultKvRequires(self, "vault-kv", mount_suffix="kv")
+        self.framework.observe(self.on.install, self._on_install)
+        self.framework.observe(self.vault_kv.on.connected, self._on_kv_connected)
+        self.framework.observe(self.vault_kv.on.ready, self._on_kv_ready)
+        self.framework.observe(self.on.create_secret_action, self._on_create_secret_action)
+        self.framework.observe(self.on.get_secret_action, self._on_get_secret_action)
+
+    def _on_install(self, event: InstallEvent):
+        """Create a secret to store the nonce."""
+        self.unit.add_secret(
+            {"nonce": secrets.token_hex(16)},
+            label=NONCE_SECRET_LABEL,
+            description="Nonce for vault-kv relation",
+        )
+        self.unit.status = ActiveStatus()
+
+    def _on_kv_connected(self, event: VaultKvConnectedEvent):
+        """Request credentials from Vault KV."""
+        relation = self.model.get_relation(event.relation_name, event.relation_id)
+        if not relation:
+            return
+        binding = self.model.get_binding(relation)
+        if not binding:
+            logger.error("Binding not found")
+            return
+        egress_subnet = str(binding.network.interfaces[0].subnet)
+        self.vault_kv.request_credentials(relation, egress_subnet, self.get_nonce())
+
+    def _on_kv_ready(self, event: VaultKvReadyEvent):
+        """Store the Vault KV credentials in a secret."""
+        if (relation := self.model.get_relation(event.relation_name, event.relation_id)) is None:
+            return
+        if not (ca_certificate := self.vault_kv.get_ca_certificate(relation)):
+            logger.error("CA certificate not found")
+            return
+        if not (vault_url := self.vault_kv.get_vault_url(relation)):
+            logger.error("Vault URL not found")
+            return
+        if not (mount := self.vault_kv.get_mount(relation)):
+            logger.error("Mount not found")
+            return
+        unit_credentials = self.vault_kv.get_unit_credentials(relation)
+        secret = self.model.get_secret(id=unit_credentials)
+        secret_content = secret.get_content()
+        juju_secret_content = {
+            "vault-url": vault_url,
+            "mount": mount,
+            "role-id": secret_content["role-id"],
+            "role-secret-id": secret_content["role-secret-id"],
+        }
+        try:
+            vault_kv_secret = self.model.get_secret(label=VAULT_KV_SECRET_LABEL)
+            vault_kv_secret.set_content(content=juju_secret_content)
+            logger.info("Vault KV secret updated")
+        except SecretNotFoundError:
+            self.app.add_secret(juju_secret_content, label=VAULT_KV_SECRET_LABEL)
+            logger.info("Vault KV secret created")
+        self._store_ca_certificate(cert=ca_certificate)
+
+    def _store_ca_certificate(self, cert: str) -> None:
+        """Store the CA certificate in the charm storage."""
+        certs_path = self._get_ca_cert_location_in_charm()
+        with open(f"{certs_path}/{VAULT_CA_CERT_FILENAME}", "w") as fd:
+            fd.write(cert)
+
+    def _on_create_secret_action(self, event: ActionEvent):
+        """Create a secret in Vault KV."""
+        try:
+            secret = self.model.get_secret(label=VAULT_KV_SECRET_LABEL)
+        except SecretNotFoundError:
+            event.fail("Vault KV secret not found")
+            return
+        secret_content = secret.get_content()
+        mount = secret_content["mount"]
+        ca_certificate_path = self._get_ca_cert_location_in_charm()
+        if ca_certificate_path is None:
+            event.fail("CA certificate not found")
+            return
+        secret_key = event.params.get("key")
+        secret_value = event.params.get("value")
+        if not secret_key or not secret_value:
+            event.fail("Missing key or value")
+            return
+        vault = Vault(
+            url=secret_content["vault-url"],
+            approle_role_id=secret_content["role-id"],
+            ca_certificate=f"{ca_certificate_path}/{VAULT_CA_CERT_FILENAME}",
+            approle_secret_id=secret_content["role-secret-id"],
+        )
+        vault.create_secret_in_kv(
+            path=VAULT_KV_SECRET_PATH, mount=mount, key=secret_key, value=secret_value
+        )
+
+    def _on_get_secret_action(self, event: ActionEvent) -> None:
+        try:
+            secret = self.model.get_secret(label=VAULT_KV_SECRET_LABEL)
+        except SecretNotFoundError:
+            event.fail("Vault KV secret not found")
+            return
+        secret_content = secret.get_content()
+        mount = secret_content["mount"]
+        ca_certificate_path = self._get_ca_cert_location_in_charm()
+        if ca_certificate_path is None:
+            event.fail("CA certificate not found")
+            return
+        secret_key = event.params.get("key")
+        if not secret_key:
+            event.fail("Missing key or value")
+            return
+        vault = Vault(
+            url=secret_content["vault-url"],
+            approle_role_id=secret_content["role-id"],
+            ca_certificate=f"{ca_certificate_path}/{VAULT_CA_CERT_FILENAME}",
+            approle_secret_id=secret_content["role-secret-id"],
+        )
+        vault_secret = vault.get_secret_in_kv(path=VAULT_KV_SECRET_PATH, mount=mount)
+        if secret_key not in vault_secret:
+            event.fail("Secret not found")
+            return
+        event.set_results({"value": vault_secret[secret_key]})
+
+    def get_nonce(self) -> str:
+        """Get the nonce from the secret."""
+        secret = self.model.get_secret(label=NONCE_SECRET_LABEL)
+        return secret.get_content()["nonce"]
+
+    def _get_ca_cert_location_in_charm(self) -> Optional[Path]:
+        """Return the CA certificate location in the charm (not in the workload).
+
+        This path would typically be: /var/lib/juju/storage/certs/0/ca.pem
+
+        Returns:
+            Path: The CA certificate location
+
+        Raises:
+            VaultCertsError: If the CA certificate is not found
+        """
+        storage = self.model.storages
+        if "certs" not in storage:
+            return None
+        if len(storage["certs"]) == 0:
+            return None
+        cert_storage = storage["certs"][0]
+        return cert_storage.location
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main(VaultKVRequirerCharm)

--- a/tests/integration/vault_kv_requirer_operator/src/vault_client.py
+++ b/tests/integration/vault_kv_requirer_operator/src/vault_client.py
@@ -1,0 +1,35 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+
+import hvac  # type: ignore[import-untyped]
+
+logger = logging.getLogger(__name__)
+
+
+class Vault:
+    def __init__(
+        self, url: str, ca_certificate: str, approle_role_id: str, approle_secret_id: str
+    ):
+        self._client = hvac.Client(url=url, verify=ca_certificate)
+        self._approle_login(approle_role_id, approle_secret_id)
+
+    def _approle_login(self, role_id: str, secret_id: str) -> None:
+        """Login to Vault using AppRole."""
+        login_response = self._client.auth.approle.login(
+            role_id=role_id, secret_id=secret_id, use_token=False
+        )
+        self._client.token = login_response["auth"]["client_token"]
+
+    def create_secret_in_kv(self, path: str, mount: str, key: str, value: str) -> None:
+        """Create a secret in Vault KV."""
+        self._client.secrets.kv.v2.create_or_update_secret(
+            path=path, secret={"data": {key: value}}, mount_point=mount
+        )
+        logger.info("Secret %s created in mount %s", key, mount)
+
+    def get_secret_in_kv(self, path: str, mount: str) -> dict:
+        """Get a secret from Vault KV."""
+        response = self._client.secrets.kv.v2.read_secret(path=path, mount_point=mount)
+        return response["data"]["data"]["data"]


### PR DESCRIPTION
# Description

Implement the vault-kv integration.

## Notes
1. There are some differences with the k8s version of the charm here, all of which are implementation details, no behavior change.
2. We should add a new method to the `vault_kv` lib to set relation data all in 1 (or 2) call, it's tedious to have to make 5 different calls.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
