### PR TITLE
chore: Bump pyright from 1.1.355 to 1.1.356

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -12,32 +12,42 @@ cachetools==5.3.3
     # via google-auth
 certifi==2024.2.2
     # via
+    #   -c requirements.txt
     #   kubernetes
     #   requests
 cffi==1.16.0
     # via
+    #   -c requirements.txt
     #   cryptography
     #   pynacl
 charset-normalizer==3.3.2
-    # via requests
+    # via
+    #   -c requirements.txt
+    #   requests
 codespell==2.2.6
     # via -r test-requirements.in
 coverage[toml]==7.4.4
     # via -r test-requirements.in
 cryptography==42.0.5
-    # via paramiko
+    # via
+    #   -c requirements.txt
+    #   paramiko
 decorator==5.1.1
     # via
     #   ipdb
     #   ipython
 executing==2.0.1
     # via stack-data
-google-auth==2.28.1
+google-auth==2.29.0
     # via kubernetes
 hvac==2.1.0
-    # via juju
+    # via
+    #   -c requirements.txt
+    #   juju
 idna==3.6
-    # via requests
+    # via
+    #   -c requirements.txt
+    #   requests
 iniconfig==2.0.0
     # via pytest
 ipdb==0.13.13
@@ -47,7 +57,9 @@ ipython==8.22.2
 jedi==0.19.1
     # via ipython
 jinja2==3.1.3
-    # via pytest-operator
+    # via
+    #   -c requirements.txt
+    #   pytest-operator
 juju==3.3.1.1
     # via
     #   -r test-requirements.in
@@ -57,7 +69,9 @@ kubernetes==29.0.0
 macaroonbakery==1.3.4
     # via juju
 markupsafe==2.1.5
-    # via jinja2
+    # via
+    #   -c requirements.txt
+    #   jinja2
 matplotlib-inline==0.1.6
     # via ipython
 mypy-extensions==1.0.0
@@ -68,7 +82,7 @@ oauthlib==3.2.2
     # via
     #   kubernetes
     #   requests-oauthlib
-packaging==23.2
+packaging==24.0
     # via
     #   juju
     #   pytest
@@ -82,21 +96,23 @@ pluggy==1.4.0
     # via pytest
 prompt-toolkit==3.0.43
     # via ipython
-protobuf==4.25.3
+protobuf==5.26.0
     # via macaroonbakery
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-pyasn1==0.5.1
+pyasn1==0.6.0
     # via
     #   juju
     #   pyasn1-modules
     #   rsa
-pyasn1-modules==0.3.0
+pyasn1-modules==0.4.0
     # via google-auth
 pycparser==2.21
-    # via cffi
+    # via
+    #   -c requirements.txt
+    #   cffi
 pygments==2.17.2
     # via ipython
 pymacaroons==0.13.0
@@ -110,7 +126,7 @@ pyrfc3339==1.1
     # via
     #   juju
     #   macaroonbakery
-pyright==1.1.355
+pyright==1.1.356
     # via -r test-requirements.in
 pytest==8.1.1
     # via
@@ -127,16 +143,18 @@ pytz==2024.1
     # via pyrfc3339
 pyyaml==6.0.1
     # via
+    #   -c requirements.txt
     #   juju
     #   kubernetes
     #   pytest-operator
 requests==2.31.0
     # via
+    #   -c requirements.txt
     #   hvac
     #   kubernetes
     #   macaroonbakery
     #   requests-oauthlib
-requests-oauthlib==1.3.1
+requests-oauthlib==2.0.0
     # via kubernetes
 rsa==4.9
     # via google-auth
@@ -153,22 +171,27 @@ stack-data==0.6.3
     # via ipython
 toposort==1.10
     # via juju
-traitlets==5.14.1
+traitlets==5.14.2
     # via
     #   ipython
     #   matplotlib-inline
 typing-extensions==4.9.0
-    # via typing-inspect
+    # via
+    #   -c requirements.txt
+    #   typing-inspect
 typing-inspect==0.9.0
     # via juju
 urllib3==2.2.1
     # via
+    #   -c requirements.txt
     #   kubernetes
     #   requests
 wcwidth==0.2.13
     # via prompt-toolkit
 websocket-client==1.7.0
-    # via kubernetes
+    # via
+    #   -c requirements.txt
+    #   kubernetes
 websockets==12.0
     # via juju
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -245,7 +245,7 @@ async def test_given_certificates_provider_is_related_when_vault_status_checked_
     vault_endpoint = f"https://{unit_ip}:8200"
     action_output = await run_get_ca_certificate_action(ops_test)
     ca_certificate = action_output["ca-certificate"]
-    ca_file_location = ops_test.tmp_path / "ca_file.txt"
+    ca_file_location = str(ops_test.tmp_path / "ca_file.txt")
     with open(ca_file_location, mode="w+") as ca_file:
         ca_file.write(ca_certificate)
     client = hvac.Client(url=vault_endpoint, verify=ca_file_location)
@@ -269,7 +269,7 @@ async def test_given_charm_deployed_when_vault_initialized_and_unsealed_and_auth
 
     action_output = await run_get_ca_certificate_action(ops_test)
     ca_certificate = action_output["ca-certificate"]
-    ca_file_location = ops_test.tmp_path / "ca_file.txt"
+    ca_file_location = str(ops_test.tmp_path / "ca_file.txt")
     with open(ca_file_location, mode="w+") as ca_file:
         ca_file.write(ca_certificate)
     client = hvac.Client(url=vault_endpoint, verify=ca_file_location)


### PR DESCRIPTION
# Description

bump pyright version and make the necessary code changes to satisfy it. This PR will make this one not necessary anymore: 
- https://github.com/canonical/vault-operator/pull/97

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
