### PR TITLE
chore: build charm before running tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,54 @@
+name: Build
+
+on:
+  workflow_call:
+
+jobs:
+  build-charm-under-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+    
+      - name: Setup LXD
+        uses: canonical/setup-lxd@main
+        with:
+            channel: latest/stable
+    
+      - name: Install charmcraft
+        run: sudo snap install charmcraft --classic
+
+      - name: Build charm under test
+        run: charmcraft pack --verbose
+
+      - name: Archive Charm Under Test
+        uses: actions/upload-artifact@v4
+        with:
+          name: built-charm
+          path: "*.charm"
+          retention-days: 5
+
+  build-kv-requirer:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Setup LXD
+        uses: canonical/setup-lxd@main
+        with:
+          channel: latest/stable
+      
+      - name: Install charmcraft
+        run: sudo snap install charmcraft --classic
+
+      - name: Build KV Requirer charm
+        run: |
+          cp lib/charms/vault_k8s/v0/vault_kv.py tests/integration/vault_kv_requirer_operator/lib/charms/vault_k8s/v0/vault_kv.py
+          cd tests/integration/vault_kv_requirer_operator
+          charmcraft pack --verbose
+
+      - name: Archive KV Requirer Charm
+        uses: actions/upload-artifact@v4
+        with:
+          name: kv-requirer-charm
+          path: tests/integration/vault_kv_requirer_operator/*.charm
+          retention-days: 5

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -2,17 +2,32 @@ name: Integration Tests
 
 on:
   workflow_call:
-    inputs:
-        charm-file-name:
-          description: Tested charm file name
-          required: true
-          type: string
 
 jobs:
   integration-tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Fetch Charm Under Test
+        uses: actions/download-artifact@v4
+        with:
+          name: built-charm
+          path: built/
+      
+      - name: Get Charm Under Test Path
+        id: charm-path
+        run: echo "::set-output name=charm_path::$(find built -name '*.charm' -type f -print)"
+      
+      - name: Fetch KV Requirer Charm
+        uses: actions/download-artifact@v4
+        with:
+          name: kv-requirer-charm
+          path: kv-requirer/
+      
+      - name: Get KV Requirer Charm Path
+        id: kv-requirer-charm-path
+        run: echo "::set-output name=kv_requirer_charm_path::$(find kv-requirer -name '*.charm' -type f -print)"
     
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
@@ -24,12 +39,4 @@ jobs:
         run: pip install tox
 
       - name: Run integration tests
-        run: tox -e integration
-
-      - name: Archive Tested Charm
-        uses: actions/upload-artifact@v4
-        if: ${{ github.ref_name == 'main' }}
-        with:
-          name: tested-charm
-          path: .tox/**/${{ inputs.charm-file-name }}
-          retention-days: 5
+        run: tox -e integration -- --vault_charm_path="./vault_ubuntu-22.04-amd64.charm" --kv_requirer_charm_path="./vault-kv-requirer_ubuntu-22.04-amd64.charm"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,14 +23,18 @@ jobs:
   unit-tests-with-coverage:
     uses: ./.github/workflows/unit-test.yaml
   
-  integration-tests:
+  build:
     needs:
       - lint-report
       - static-analysis
       - unit-tests-with-coverage
+    uses: ./.github/workflows/build.yaml
+    secrets: inherit
+  
+  integration-tests:
+    needs:
+      - build
     uses: ./.github/workflows/integration-tests.yaml
-    with:
-      charm-file-name: "vault_ubuntu-22.04-amd64.charm"
     secrets: inherit
 
   publish-charm:
@@ -38,9 +42,8 @@ jobs:
       - lint-report
       - static-analysis
       - unit-tests-with-coverage
+      - build
       - integration-tests
     if: ${{ github.ref_name == 'main' }}
     uses: ./.github/workflows/publish-charm.yaml
-    with:
-      charm-file-name: "vault_ubuntu-22.04-amd64.charm"
     secrets: inherit

--- a/.github/workflows/publish-charm.yaml
+++ b/.github/workflows/publish-charm.yaml
@@ -2,11 +2,6 @@ name: Publish charm
 
 on:
   workflow_call:
-    inputs:
-      charm-file-name:
-        description: Charm file name
-        required: true
-        type: string
     secrets:
       CHARMCRAFT_AUTH:
         required: true
@@ -21,15 +16,17 @@ jobs:
       - name: Fetch Tested Charm
         uses: actions/download-artifact@v4
         with:
-          name: tested-charm
-
-      - name: Move charm in current directory
-        run: find ./ -name ${{ inputs.charm-file-name }} -exec mv -t ./ {} \;
+          name: built-charm
+      
+      - name: Get charm file name
+        id: charm-file-name
+        run: |
+          echo "::set-output name=charm-file-name::$(find ./ -name '*.charm' -type f -exec basename {} \;)"
 
       - name: Upload charm to Charmhub
         uses: canonical/charming-actions/upload-charm@2.4.0
         with:
-          built-charm-path: ${{ inputs.charm-file-name }}
+          built-charm-path: ${{ steps.charm-file-name.outputs.charm-file-name }}
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           channel: 1.15/edge

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import os
+
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption("--vault_charm_path", action="store", default=None, help="Path to the Vault charm")
+    parser.addoption("--kv_requirer_charm_path", action="store", default=None, help="Path to the KV requirer charm")
+
+def pytest_configure(config):
+    vault_charm_path = config.getoption("--vault_charm_path")
+    kv_requirer_charm_path = config.getoption("--kv_requirer_charm_path")
+    if not vault_charm_path:
+        pytest.exit("The --vault_charm_path option is required. Tests aborted.")
+    if not kv_requirer_charm_path:
+        pytest.exit("The --kv_requirer_charm_path option is required. Tests aborted.")
+    if not os.path.exists(vault_charm_path):
+        pytest.exit(f"The path specified does not exist: {vault_charm_path}")
+    if not os.path.exists(kv_requirer_charm_path):
+        pytest.exit(f"The path specified does not exist: {kv_requirer_charm_path}")

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -4,7 +4,6 @@
 
 import asyncio
 import logging
-import shutil
 import time
 from os.path import abspath
 from pathlib import Path
@@ -113,25 +112,22 @@ async def wait_for_certificate_to_be_provided(ops_test: OpsTest) -> None:
     raise TimeoutError("Timed out waiting for certificate to be provided.")
 
 @pytest.fixture(scope="module")
-async def build_and_deploy(ops_test: OpsTest) -> dict[str, Path | str]:
+async def deploy_vault(ops_test: OpsTest, request) -> None:
     """Build the charm-under-test and deploy it."""
     assert ops_test.model
-    copy_lib_content()
-    built_charms = await ops_test.build_charms(".", f"{VAULT_KV_REQUIRER_CHARM_DIR}/")
-    vault_charm = built_charms.get(APP_NAME, "")
-    vault_kv_requirer_charm = built_charms.get("vault-kv-requirer", "")
+    vault_charm_path = Path(request.config.getoption("--vault_charm_path")).resolve()
     await ops_test.model.deploy(
-        vault_charm,
+        vault_charm_path,
         application_name=APP_NAME,
-        trust=True,
         num_units=NUM_VAULT_UNITS,
         config={"common_name": "example.com"},
     )
-    return {"vault-kv-requirer": vault_kv_requirer_charm}
+
 
 @pytest.fixture(scope="module")
-async def deploy_requiring_charms(ops_test: OpsTest, build_and_deploy: dict[str, Path | str]):
+async def deploy_requiring_charms(ops_test: OpsTest, deploy_vault: None, request):
     assert ops_test.model
+    kv_requirer_charm_path = Path(request.config.getoption("--kv_requirer_charm_path")).resolve()
     deploy_self_signed_certificates = ops_test.model.deploy(
         SELF_SIGNED_CERTIFICATES_APPLICATION_NAME,
         application_name=SELF_SIGNED_CERTIFICATES_APPLICATION_NAME,
@@ -139,7 +135,7 @@ async def deploy_requiring_charms(ops_test: OpsTest, build_and_deploy: dict[str,
         channel="stable",
     )
     deploy_vault_kv_requirer = ops_test.model.deploy(
-        build_and_deploy.get("vault-kv-requirer", ""),
+        kv_requirer_charm_path,
         application_name=VAULT_KV_REQUIRER_APPLICATION_NAME,
         num_units=1,
     )
@@ -166,7 +162,7 @@ async def deploy_requiring_charms(ops_test: OpsTest, build_and_deploy: dict[str,
         deploy_self_signed_certificates,
         deploy_vault_kv_requirer,
         deploy_vault_pki_requirer,
-        deploy_grafana_agent
+        deploy_grafana_agent,
     )
     await ops_test.model.wait_for_idle(
         apps=[
@@ -401,6 +397,3 @@ async def test_given_vault_pki_relation_when_integrate_then_cert_is_provided(
     assert action_output.get("certificate", None) is not None
     assert action_output.get("ca-certificate", None) is not None
     assert action_output.get("csr", None) is not None
-
-def copy_lib_content() -> None:
-    shutil.copyfile(src=VAULT_KV_LIB_DIR, dst=f"{VAULT_KV_REQUIRER_CHARM_DIR}/{VAULT_KV_LIB_DIR}")


### PR DESCRIPTION
# Description

We move the charm build process to its own workflow stage. 

## Rationale

1. While working on the backup/restore task, I kept getting github runners issues where the runners were getting out of space. Here by moving the build stage prior, the integration tests get leaner in terms of space and time to complete.
2. This will make it more obvious that tests fail in cases where the build doesn't complete. 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
