### PR TITLE
feat: implement backup action

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -11,3 +11,8 @@ authorize-charm:
         that is provided upon initializing Vault. Used to create the app role
         and policy for the charm. It is not stored by the charm.
   required: [token]
+
+create-backup:
+  description: >-
+    Creates a snapshot of the Raft backend and saves it to the S3 storage.
+    Returns backup ID.

--- a/lib/charms/data_platform_libs/v0/s3.py
+++ b/lib/charms/data_platform_libs/v0/s3.py
@@ -1,0 +1,768 @@
+# Copyright 2023 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+r"""A library for communicating with the S3 credentials providers and consumers.
+
+This library provides the relevant interface code implementing the communication
+specification for fetching, retrieving, triggering, and responding to events related to
+the S3 provider charm and its consumers.
+
+### Provider charm
+
+The provider is implemented in the `s3-provider` charm which is meant to be deployed
+alongside one or more consumer charms. The provider charm is serving the s3 credentials and
+metadata needed to communicate and work with an S3 compatible backend.
+
+Example:
+```python
+
+from charms.data_platform_libs.v0.s3 import CredentialRequestedEvent, S3Provider
+
+
+class ExampleProviderCharm(CharmBase):
+    def __init__(self, *args) -> None:
+        super().__init__(*args)
+        self.s3_provider = S3Provider(self, "s3-credentials")
+
+        self.framework.observe(self.s3_provider.on.credentials_requested,
+            self._on_credential_requested)
+
+    def _on_credential_requested(self, event: CredentialRequestedEvent):
+        if not self.unit.is_leader():
+            return
+
+        # get relation id
+        relation_id = event.relation.id
+
+        # get bucket name
+        bucket = event.bucket
+
+        # S3 configuration parameters
+        desired_configuration = {"access-key": "your-access-key", "secret-key":
+            "your-secret-key", "bucket": "your-bucket"}
+
+        # update the configuration
+        self.s3_provider.update_connection_info(relation_id, desired_configuration)
+
+        # or it is possible to set each field independently
+
+        self.s3_provider.set_secret_key(relation_id, "your-secret-key")
+
+
+if __name__ == "__main__":
+    main(ExampleProviderCharm)
+
+
+### Requirer charm
+
+The requirer charm is the charm requiring the S3 credentials.
+An example of requirer charm is the following:
+
+Example:
+```python
+
+from charms.data_platform_libs.v0.s3 import (
+    CredentialsChangedEvent,
+    CredentialsGoneEvent,
+    S3Requirer
+)
+
+class ExampleRequirerCharm(CharmBase):
+
+    def __init__(self, *args):
+        super().__init__(*args)
+
+         bucket_name = "test-bucket"
+        # if bucket name is not provided the bucket name will be generated
+        # e.g., ('relation-{relation.id}')
+
+        self.s3_client = S3Requirer(self, "s3-credentials", bucket_name)
+
+        self.framework.observe(self.s3_client.on.credentials_changed, self._on_credential_changed)
+        self.framework.observe(self.s3_client.on.credentials_gone, self._on_credential_gone)
+
+    def _on_credential_changed(self, event: CredentialsChangedEvent):
+
+        # access single parameter credential
+        secret_key = event.secret_key
+        access_key = event.access_key
+
+        # or as alternative all credentials can be collected as a dictionary
+        credentials = self.s3_client.get_s3_credentials()
+
+    def _on_credential_gone(self, event: CredentialsGoneEvent):
+        # credentials are removed
+        pass
+
+ if __name__ == "__main__":
+    main(ExampleRequirerCharm)
+```
+
+"""
+import json
+import logging
+from collections import namedtuple
+from typing import Dict, List, Optional, Union
+
+import ops.charm
+import ops.framework
+import ops.model
+from ops.charm import (
+    CharmBase,
+    CharmEvents,
+    RelationBrokenEvent,
+    RelationChangedEvent,
+    RelationEvent,
+    RelationJoinedEvent,
+)
+from ops.framework import EventSource, Object, ObjectEvents
+from ops.model import Application, Relation, RelationDataContent, Unit
+
+# The unique Charmhub library identifier, never change it
+LIBID = "fca396f6254246c9bfa565b1f85ab528"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 4
+
+logger = logging.getLogger(__name__)
+
+Diff = namedtuple("Diff", "added changed deleted")
+Diff.__doc__ = """
+A tuple for storing the diff between two data mappings.
+
+added - keys that were added
+changed - keys that still exist but have new values
+deleted - key that were deleted"""
+
+
+def diff(event: RelationChangedEvent, bucket: Union[Unit, Application]) -> Diff:
+    """Retrieves the diff of the data in the relation changed databag.
+
+    Args:
+        event: relation changed event.
+        bucket: bucket of the databag (app or unit)
+
+    Returns:
+        a Diff instance containing the added, deleted and changed
+            keys from the event relation databag.
+    """
+    # Retrieve the old data from the data key in the application relation databag.
+    old_data = json.loads(event.relation.data[bucket].get("data", "{}"))
+    # Retrieve the new data from the event relation databag.
+    new_data = (
+        {key: value for key, value in event.relation.data[event.app].items() if key != "data"}
+        if event.app
+        else {}
+    )
+
+    # These are the keys that were added to the databag and triggered this event.
+    added = new_data.keys() - old_data.keys()
+    # These are the keys that were removed from the databag and triggered this event.
+    deleted = old_data.keys() - new_data.keys()
+    # These are the keys that already existed in the databag,
+    # but had their values changed.
+    changed = {key for key in old_data.keys() & new_data.keys() if old_data[key] != new_data[key]}
+
+    # TODO: evaluate the possibility of losing the diff if some error
+    # happens in the charm before the diff is completely checked (DPE-412).
+    # Convert the new_data to a serializable format and save it for a next diff check.
+    event.relation.data[bucket].update({"data": json.dumps(new_data)})
+
+    # Return the diff with all possible changes.
+    return Diff(added, changed, deleted)
+
+
+class BucketEvent(RelationEvent):
+    """Base class for bucket events."""
+
+    @property
+    def bucket(self) -> Optional[str]:
+        """Returns the bucket was requested."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("bucket", "")
+
+
+class CredentialRequestedEvent(BucketEvent):
+    """Event emitted when a set of credential is requested for use on this relation."""
+
+
+class S3CredentialEvents(CharmEvents):
+    """Event descriptor for events raised by S3Provider."""
+
+    credentials_requested = EventSource(CredentialRequestedEvent)
+
+
+class S3Provider(Object):
+    """A provider handler for communicating S3 credentials to consumers."""
+
+    on = S3CredentialEvents()  # pyright: ignore [reportGeneralTypeIssues]
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relation_name: str,
+    ):
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.local_app = self.charm.model.app
+        self.local_unit = self.charm.unit
+        self.relation_name = relation_name
+
+        # monitor relation changed event for changes in the credentials
+        self.framework.observe(charm.on[relation_name].relation_changed, self._on_relation_changed)
+
+    def _on_relation_changed(self, event: RelationChangedEvent) -> None:
+        """React to the relation changed event by consuming data."""
+        if not self.charm.unit.is_leader():
+            return
+        diff = self._diff(event)
+        # emit on credential requested if bucket is provided by the requirer application
+        if "bucket" in diff.added:
+            getattr(self.on, "credentials_requested").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+
+    def _load_relation_data(self, raw_relation_data: dict) -> dict:
+        """Loads relation data from the relation data bag.
+
+        Args:
+            raw_relation_data: Relation data from the databag
+        Returns:
+            dict: Relation data in dict format.
+        """
+        connection_data = {}
+        for key in raw_relation_data:
+            try:
+                connection_data[key] = json.loads(raw_relation_data[key])
+            except (json.decoder.JSONDecodeError, TypeError):
+                connection_data[key] = raw_relation_data[key]
+        return connection_data
+
+    # def _diff(self, event: RelationChangedEvent) -> Diff:
+    #     """Retrieves the diff of the data in the relation changed databag.
+
+    #     Args:
+    #         event: relation changed event.
+
+    #     Returns:
+    #         a Diff instance containing the added, deleted and changed
+    #             keys from the event relation databag.
+    #     """
+    #     # Retrieve the old data from the data key in the application relation databag.
+    #     old_data = json.loads(event.relation.data[self.local_app].get("data", "{}"))
+    #     # Retrieve the new data from the event relation databag.
+    #     new_data = {
+    #         key: value for key, value in event.relation.data[event.app].items() if key != "data"
+    #     }
+
+    #     # These are the keys that were added to the databag and triggered this event.
+    #     added = new_data.keys() - old_data.keys()
+    #     # These are the keys that were removed from the databag and triggered this event.
+    #     deleted = old_data.keys() - new_data.keys()
+    #     # These are the keys that already existed in the databag,
+    #     # but had their values changed.
+    #     changed = {
+    #         key for key in old_data.keys() & new_data.keys() if old_data[key] != new_data[key]
+    #     }
+
+    #     # TODO: evaluate the possibility of losing the diff if some error
+    #     # happens in the charm before the diff is completely checked (DPE-412).
+    #     # Convert the new_data to a serializable format and save it for a next diff check.
+    #     event.relation.data[self.local_app].update({"data": json.dumps(new_data)})
+
+    #     # Return the diff with all possible changes.
+    #     return Diff(added, changed, deleted)
+
+    def _diff(self, event: RelationChangedEvent) -> Diff:
+        """Retrieves the diff of the data in the relation changed databag.
+
+        Args:
+            event: relation changed event.
+
+        Returns:
+            a Diff instance containing the added, deleted and changed
+                keys from the event relation databag.
+        """
+        return diff(event, self.local_app)
+
+    def fetch_relation_data(self) -> dict:
+        """Retrieves data from relation.
+
+        This function can be used to retrieve data from a relation
+        in the charm code when outside an event callback.
+
+        Returns:
+            a dict of the values stored in the relation data bag
+                for all relation instances (indexed by the relation id).
+        """
+        data = {}
+        for relation in self.relations:
+            data[relation.id] = (
+                {key: value for key, value in relation.data[relation.app].items() if key != "data"}
+                if relation.app
+                else {}
+            )
+        return data
+
+    def update_connection_info(self, relation_id: int, connection_data: dict) -> None:
+        """Updates the credential data as set of key-value pairs in the relation.
+
+        This function writes in the application data bag, therefore,
+        only the leader unit can call it.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            connection_data: dict containing the key-value pairs
+                that should be updated.
+        """
+        # check and write changes only if you are the leader
+        if not self.local_unit.is_leader():
+            return
+
+        relation = self.charm.model.get_relation(self.relation_name, relation_id)
+
+        if not relation:
+            return
+
+        # configuration options that are list
+        s3_list_options = ["attributes", "tls-ca-chain"]
+
+        # update the databag, if connection data did not change with respect to before
+        # the relation changed event is not triggered
+        updated_connection_data = {}
+        for configuration_option, configuration_value in connection_data.items():
+            if configuration_option in s3_list_options:
+                updated_connection_data[configuration_option] = json.dumps(configuration_value)
+            else:
+                updated_connection_data[configuration_option] = configuration_value
+
+        relation.data[self.local_app].update(updated_connection_data)
+        logger.debug(f"Updated S3 connection info: {updated_connection_data}")
+
+    @property
+    def relations(self) -> List[Relation]:
+        """The list of Relation instances associated with this relation_name."""
+        return list(self.charm.model.relations[self.relation_name])
+
+    def set_bucket(self, relation_id: int, bucket: str) -> None:
+        """Sets bucket name in application databag.
+
+        This function writes in the application data bag, therefore,
+        only the leader unit can call it.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            bucket: the bucket name.
+        """
+        self.update_connection_info(relation_id, {"bucket": bucket})
+
+    def set_access_key(self, relation_id: int, access_key: str) -> None:
+        """Sets access-key value in application databag.
+
+        This function writes in the application data bag, therefore,
+        only the leader unit can call it.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            access_key: the access-key value.
+        """
+        self.update_connection_info(relation_id, {"access-key": access_key})
+
+    def set_secret_key(self, relation_id: int, secret_key: str) -> None:
+        """Sets the secret key value in application databag.
+
+        This function writes in the application data bag, therefore,
+        only the leader unit can call it.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            secret_key: the value of the secret key.
+        """
+        self.update_connection_info(relation_id, {"secret-key": secret_key})
+
+    def set_path(self, relation_id: int, path: str) -> None:
+        """Sets the path value in application databag.
+
+        This function writes in the application data bag, therefore,
+        only the leader unit can call it.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            path: the path value.
+        """
+        self.update_connection_info(relation_id, {"path": path})
+
+    def set_endpoint(self, relation_id: int, endpoint: str) -> None:
+        """Sets the endpoint address in application databag.
+
+        This function writes in the application data bag, therefore,
+        only the leader unit can call it.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            endpoint: the endpoint address.
+        """
+        self.update_connection_info(relation_id, {"endpoint": endpoint})
+
+    def set_region(self, relation_id: int, region: str) -> None:
+        """Sets the region location in application databag.
+
+        This function writes in the application data bag, therefore,
+        only the leader unit can call it.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            region: the region address.
+        """
+        self.update_connection_info(relation_id, {"region": region})
+
+    def set_s3_uri_style(self, relation_id: int, s3_uri_style: str) -> None:
+        """Sets the S3 URI style in application databag.
+
+        This function writes in the application data bag, therefore,
+        only the leader unit can call it.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            s3_uri_style: the s3 URI style.
+        """
+        self.update_connection_info(relation_id, {"s3-uri-style": s3_uri_style})
+
+    def set_storage_class(self, relation_id: int, storage_class: str) -> None:
+        """Sets the storage class in application databag.
+
+        This function writes in the application data bag, therefore,
+        only the leader unit can call it.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            storage_class: the storage class.
+        """
+        self.update_connection_info(relation_id, {"storage-class": storage_class})
+
+    def set_tls_ca_chain(self, relation_id: int, tls_ca_chain: List[str]) -> None:
+        """Sets the tls_ca_chain value in application databag.
+
+        This function writes in the application data bag, therefore,
+        only the leader unit can call it.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            tls_ca_chain: the TLS Chain value.
+        """
+        self.update_connection_info(relation_id, {"tls-ca-chain": tls_ca_chain})
+
+    def set_s3_api_version(self, relation_id: int, s3_api_version: str) -> None:
+        """Sets the S3 API version in application databag.
+
+        This function writes in the application data bag, therefore,
+        only the leader unit can call it.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            s3_api_version: the S3 version value.
+        """
+        self.update_connection_info(relation_id, {"s3-api-version": s3_api_version})
+
+    def set_attributes(self, relation_id: int, attributes: List[str]) -> None:
+        """Sets the connection attributes in application databag.
+
+        This function writes in the application data bag, therefore,
+        only the leader unit can call it.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            attributes: the attributes value.
+        """
+        self.update_connection_info(relation_id, {"attributes": attributes})
+
+
+class S3Event(RelationEvent):
+    """Base class for S3 storage events."""
+
+    @property
+    def bucket(self) -> Optional[str]:
+        """Returns the bucket name."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("bucket")
+
+    @property
+    def access_key(self) -> Optional[str]:
+        """Returns the access key."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("access-key")
+
+    @property
+    def secret_key(self) -> Optional[str]:
+        """Returns the secret key."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("secret-key")
+
+    @property
+    def path(self) -> Optional[str]:
+        """Returns the path where data can be stored."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("path")
+
+    @property
+    def endpoint(self) -> Optional[str]:
+        """Returns the endpoint address."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("endpoint")
+
+    @property
+    def region(self) -> Optional[str]:
+        """Returns the region."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("region")
+
+    @property
+    def s3_uri_style(self) -> Optional[str]:
+        """Returns the s3 uri style."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("s3-uri-style")
+
+    @property
+    def storage_class(self) -> Optional[str]:
+        """Returns the storage class name."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("storage-class")
+
+    @property
+    def tls_ca_chain(self) -> Optional[List[str]]:
+        """Returns the TLS CA chain."""
+        if not self.relation.app:
+            return None
+
+        tls_ca_chain = self.relation.data[self.relation.app].get("tls-ca-chain")
+        if tls_ca_chain is not None:
+            return json.loads(tls_ca_chain)
+        return None
+
+    @property
+    def s3_api_version(self) -> Optional[str]:
+        """Returns the S3 API version."""
+        if not self.relation.app:
+            return None
+
+        return self.relation.data[self.relation.app].get("s3-api-version")
+
+    @property
+    def attributes(self) -> Optional[List[str]]:
+        """Returns the attributes."""
+        if not self.relation.app:
+            return None
+
+        attributes = self.relation.data[self.relation.app].get("attributes")
+        if attributes is not None:
+            return json.loads(attributes)
+        return None
+
+
+class CredentialsChangedEvent(S3Event):
+    """Event emitted when S3 credential are changed on this relation."""
+
+
+class CredentialsGoneEvent(RelationEvent):
+    """Event emitted when S3 credential are removed from this relation."""
+
+
+class S3CredentialRequiresEvents(ObjectEvents):
+    """Event descriptor for events raised by the S3Provider."""
+
+    credentials_changed = EventSource(CredentialsChangedEvent)
+    credentials_gone = EventSource(CredentialsGoneEvent)
+
+
+S3_REQUIRED_OPTIONS = ["access-key", "secret-key"]
+
+
+class S3Requirer(Object):
+    """Requires-side of the s3 relation."""
+
+    on = S3CredentialRequiresEvents()  # pyright: ignore[reportGeneralTypeIssues]
+
+    def __init__(
+        self, charm: ops.charm.CharmBase, relation_name: str, bucket_name: Optional[str] = None
+    ):
+        """Manager of the s3 client relations."""
+        super().__init__(charm, relation_name)
+
+        self.relation_name = relation_name
+        self.charm = charm
+        self.local_app = self.charm.model.app
+        self.local_unit = self.charm.unit
+        self.bucket = bucket_name
+
+        self.framework.observe(
+            self.charm.on[self.relation_name].relation_changed, self._on_relation_changed
+        )
+
+        self.framework.observe(
+            self.charm.on[self.relation_name].relation_joined, self._on_relation_joined
+        )
+
+        self.framework.observe(
+            self.charm.on[self.relation_name].relation_broken,
+            self._on_relation_broken,
+        )
+
+    def _generate_bucket_name(self, event: RelationJoinedEvent):
+        """Returns the bucket name generated from relation id."""
+        return f"relation-{event.relation.id}"
+
+    def _on_relation_joined(self, event: RelationJoinedEvent) -> None:
+        """Event emitted when the application joins the s3 relation."""
+        if self.bucket is None:
+            self.bucket = self._generate_bucket_name(event)
+        self.update_connection_info(event.relation.id, {"bucket": self.bucket})
+
+    def fetch_relation_data(self) -> dict:
+        """Retrieves data from relation.
+
+        This function can be used to retrieve data from a relation
+        in the charm code when outside an event callback.
+
+        Returns:
+            a dict of the values stored in the relation data bag
+                for all relation instances (indexed by the relation id).
+        """
+        data = {}
+
+        for relation in self.relations:
+            data[relation.id] = self._load_relation_data(relation.data[self.charm.app])
+        return data
+
+    def update_connection_info(self, relation_id: int, connection_data: dict) -> None:
+        """Updates the credential data as set of key-value pairs in the relation.
+
+        This function writes in the application data bag, therefore,
+        only the leader unit can call it.
+
+        Args:
+            relation_id: the identifier for a particular relation.
+            connection_data: dict containing the key-value pairs
+                that should be updated.
+        """
+        # check and write changes only if you are the leader
+        if not self.local_unit.is_leader():
+            return
+
+        relation = self.charm.model.get_relation(self.relation_name, relation_id)
+
+        if not relation:
+            return
+
+        # update the databag, if connection data did not change with respect to before
+        # the relation changed event is not triggered
+        # configuration options that are list
+        s3_list_options = ["attributes", "tls-ca-chain"]
+        updated_connection_data = {}
+        for configuration_option, configuration_value in connection_data.items():
+            if configuration_option in s3_list_options:
+                updated_connection_data[configuration_option] = json.dumps(configuration_value)
+            else:
+                updated_connection_data[configuration_option] = configuration_value
+
+        relation.data[self.local_app].update(updated_connection_data)
+        logger.debug(f"Updated S3 credentials: {updated_connection_data}")
+
+    def _load_relation_data(self, raw_relation_data: RelationDataContent) -> Dict[str, str]:
+        """Loads relation data from the relation data bag.
+
+        Args:
+            raw_relation_data: Relation data from the databag
+        Returns:
+            dict: Relation data in dict format.
+        """
+        connection_data = {}
+        for key in raw_relation_data:
+            try:
+                connection_data[key] = json.loads(raw_relation_data[key])
+            except (json.decoder.JSONDecodeError, TypeError):
+                connection_data[key] = raw_relation_data[key]
+        return connection_data
+
+    def _diff(self, event: RelationChangedEvent) -> Diff:
+        """Retrieves the diff of the data in the relation changed databag.
+
+        Args:
+            event: relation changed event.
+
+        Returns:
+            a Diff instance containing the added, deleted and changed
+                keys from the event relation databag.
+        """
+        return diff(event, self.local_unit)
+
+    def _on_relation_changed(self, event: RelationChangedEvent) -> None:
+        """Notify the charm about the presence of S3 credentials."""
+        # check if the mandatory options are in the relation data
+        contains_required_options = True
+        # get current credentials data
+        credentials = self.get_s3_connection_info()
+        # records missing options
+        missing_options = []
+        for configuration_option in S3_REQUIRED_OPTIONS:
+            if configuration_option not in credentials:
+                contains_required_options = False
+                missing_options.append(configuration_option)
+        # emit credential change event only if all mandatory fields are present
+        if contains_required_options:
+            getattr(self.on, "credentials_changed").emit(
+                event.relation, app=event.app, unit=event.unit
+            )
+        else:
+            logger.warning(
+                f"Some mandatory fields: {missing_options} are not present, do not emit credential change event!"
+            )
+
+    def get_s3_connection_info(self) -> Dict[str, str]:
+        """Return the s3 credentials as a dictionary."""
+        for relation in self.relations:
+            if relation and relation.app:
+                return self._load_relation_data(relation.data[relation.app])
+
+        return {}
+
+    def _on_relation_broken(self, event: RelationBrokenEvent) -> None:
+        """Notify the charm about a broken S3 credential store relation."""
+        getattr(self.on, "credentials_gone").emit(event.relation, app=event.app, unit=event.unit)
+
+    @property
+    def relations(self) -> List[Relation]:
+        """The list of Relation instances associated with this relation_name."""
+        return list(self.charm.model.relations[self.relation_name])

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -60,3 +60,5 @@ requires:
     description: |
       Interface to be used to provide Vault with its CA certificate. Vault will
       use this certificate to sign the certificates it issues on the `vault-pki` interface.
+  s3-parameters:
+    interface: s3

--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,5 @@
+boto3
+boto3-stubs[s3]
 cosl
 cryptography
 jinja2
@@ -5,6 +7,7 @@ jsonschema
 ops
 psutil
 pyhcl
+pyopenssl
 pytest-interface-tester
 # cos-agent requires pydantic<2
 pydantic<2

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,16 @@ attrs==23.2.0
     # via
     #   jsonschema
     #   referencing
+boto3==1.34.77
+    # via -r requirements.in
+boto3-stubs[s3]==1.34.77
+    # via -r requirements.in
+botocore==1.34.77
+    # via
+    #   boto3
+    #   s3transfer
+botocore-stubs==1.34.69
+    # via boto3-stubs
 certifi==2024.2.2
     # via requests
 cffi==1.16.0
@@ -19,7 +29,9 @@ click==8.1.7
 cosl==0.0.10
     # via -r requirements.in
 cryptography==42.0.5
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   pyopenssl
 hvac==2.1.0
     # via -r requirements.in
 idna==3.6
@@ -28,12 +40,18 @@ iniconfig==2.0.0
     # via pytest
 jinja2==3.1.3
     # via -r requirements.in
+jmespath==1.0.1
+    # via
+    #   boto3
+    #   botocore
 jsonschema==4.21.1
     # via -r requirements.in
 jsonschema-specifications==2023.12.1
     # via jsonschema
 markupsafe==2.1.5
     # via jinja2
+mypy-boto3-s3==1.34.65
+    # via boto3-stubs
 ops==2.12.0
     # via
     #   -r requirements.in
@@ -47,18 +65,22 @@ pluggy==1.4.0
     # via pytest
 psutil==5.9.8
     # via -r requirements.in
-pycparser==2.21
+pycparser==2.22
     # via cffi
-pydantic==1.10.14
+pydantic==1.10.15
     # via
     #   -r requirements.in
     #   pytest-interface-tester
 pyhcl==0.4.5
     # via -r requirements.in
+pyopenssl==24.1.0
+    # via -r requirements.in
 pytest==8.1.1
     # via pytest-interface-tester
 pytest-interface-tester==2.0.1
     # via -r requirements.in
+python-dateutil==2.9.0.post0
+    # via botocore
 pyyaml==6.0.1
     # via
     #   cosl
@@ -74,13 +96,25 @@ rpds-py==0.18.0
     # via
     #   jsonschema
     #   referencing
+s3transfer==0.10.1
+    # via boto3
+six==1.16.0
+    # via python-dateutil
 typer==0.7.0
     # via pytest-interface-tester
+types-awscrt==0.20.5
+    # via botocore-stubs
+types-s3transfer==0.10.0
+    # via boto3-stubs
 typing-extensions==4.10.0
     # via
+    #   boto3-stubs
     #   cosl
+    #   mypy-boto3-s3
     #   pydantic
 urllib3==2.2.1
-    # via requests
+    # via
+    #   botocore
+    #   requests
 websocket-client==1.7.0
     # via ops

--- a/src/charm.py
+++ b/src/charm.py
@@ -433,7 +433,7 @@ class VaultOperatorCharm(CharmBase):
                 endpoint=s3_parameters["endpoint"],
                 region=s3_parameters.get("region"),
             )
-        except S3Error as e:
+        except S3Error:
             event.fail(message="Failed to create S3 session.")
             return
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -413,7 +413,6 @@ class VaultOperatorCharm(CharmBase):
             event: ActionEvent
         """
         if not self.unit.is_leader():
-            logger.error("Only leader unit can perform backup operations.")
             event.fail(message="Only leader unit can perform backup operations.")
             return
 
@@ -435,12 +434,10 @@ class VaultOperatorCharm(CharmBase):
                 region=s3_parameters.get("region"),
             )
         except S3Error as e:
-            logger.error("Failed to create S3 session: %s", e)
             event.fail(message="Failed to create S3 session.")
             return
 
         if not (s3.create_bucket(bucket_name=s3_parameters["bucket"])):
-            logger.error("Failed to create S3 bucket")
             event.fail(message="Failed to create S3 bucket.")
             return
         backup_key = self._get_backup_key()
@@ -460,7 +457,6 @@ class VaultOperatorCharm(CharmBase):
             key=backup_key,
         )
         if not content_uploaded:
-            logger.error("Failed to upload backup to S3 bucket")
             event.fail(message="Failed to upload backup to S3 bucket.")
             return
         logger.info("Backup uploaded to S3 bucket %s", s3_parameters["bucket"])

--- a/src/charm.py
+++ b/src/charm.py
@@ -435,12 +435,12 @@ class VaultOperatorCharm(CharmBase):
             )
         except S3Error:
             event.fail(message="Failed to create S3 session.")
-            logger.warning("Failed to run create-backup action - Failed to create S3 session.")
+            logger.error("Failed to run create-backup action - Failed to create S3 session.")
             return
 
         if not (s3.create_bucket(bucket_name=s3_parameters["bucket"])):
             event.fail(message="Failed to create S3 bucket.")
-            logger.warning("Failed to run create-backup action - Failed to create S3 bucket.")
+            logger.error("Failed to run create-backup action - Failed to create S3 bucket.")
             return
         backup_key = self._get_backup_key()
         vault = self._get_vault_client()
@@ -451,7 +451,7 @@ class VaultOperatorCharm(CharmBase):
             or vault.is_sealed()
         ):
             event.fail(message="Failed to initialize Vault client.")
-            logger.warning("Failed to run create-backup action - Failed to initialize Vault client.")
+            logger.error("Failed to run create-backup action - Failed to initialize Vault client.")
             return
         response = vault.create_snapshot()
         content_uploaded = s3.upload_content(
@@ -461,7 +461,7 @@ class VaultOperatorCharm(CharmBase):
         )
         if not content_uploaded:
             event.fail(message="Failed to upload backup to S3 bucket.")
-            logger.warning("Failed to run create-backup action - Failed to upload backup to S3 bucket.")
+            logger.error("Failed to run create-backup action - Failed to upload backup to S3 bucket.")
             return
         logger.info("Backup uploaded to S3 bucket %s", s3_parameters["bucket"])
         event.set_results({"backup-id": backup_key})

--- a/src/charm.py
+++ b/src/charm.py
@@ -435,10 +435,12 @@ class VaultOperatorCharm(CharmBase):
             )
         except S3Error:
             event.fail(message="Failed to create S3 session.")
+            logger.warning("Failed to run create-backup action - Failed to create S3 session.")
             return
 
         if not (s3.create_bucket(bucket_name=s3_parameters["bucket"])):
             event.fail(message="Failed to create S3 bucket.")
+            logger.warning("Failed to run create-backup action - Failed to create S3 bucket.")
             return
         backup_key = self._get_backup_key()
         vault = self._get_vault_client()
@@ -449,6 +451,7 @@ class VaultOperatorCharm(CharmBase):
             or vault.is_sealed()
         ):
             event.fail(message="Failed to initialize Vault client.")
+            logger.warning("Failed to run create-backup action - Failed to initialize Vault client.")
             return
         response = vault.create_snapshot()
         content_uploaded = s3.upload_content(
@@ -458,6 +461,7 @@ class VaultOperatorCharm(CharmBase):
         )
         if not content_uploaded:
             event.fail(message="Failed to upload backup to S3 bucket.")
+            logger.warning("Failed to run create-backup action - Failed to upload backup to S3 bucket.")
             return
         logger.info("Backup uploaded to S3 bucket %s", s3_parameters["bucket"])
         event.set_results({"backup-id": backup_key})

--- a/src/charm.py
+++ b/src/charm.py
@@ -5,11 +5,13 @@
 
 """A machine charm for Vault."""
 
+import datetime
 import logging
 from contextlib import contextmanager
 from typing import Dict, List, Optional, Tuple
 
 import hcl
+from charms.data_platform_libs.v0.s3 import S3Requirer
 from charms.grafana_agent.v0.cos_agent import COSAgentProvider
 from charms.operator_libs_linux.v2 import snap
 from charms.tls_certificates_interface.v3.tls_certificates import (
@@ -38,6 +40,7 @@ from ops import ActionEvent, BlockedStatus, ErrorStatus, Secret, SecretNotFoundE
 from ops.charm import CharmBase, CollectStatusEvent, RelationJoinedEvent
 from ops.main import main
 from ops.model import ActiveStatus, MaintenanceStatus, ModelError, Relation, WaitingStatus
+from s3_session import S3, S3Error
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +50,8 @@ MACHINE_TLS_FILE_DIRECTORY_PATH = "/var/snap/vault/common/certs"
 PEER_RELATION_NAME = "vault-peers"
 PKI_RELATION_NAME = "vault-pki"
 KV_RELATION_NAME = "vault-kv"
+S3_RELATION_NAME = "s3-parameters"
+REQUIRED_S3_PARAMETERS = ["bucket", "access-key", "secret-key", "endpoint"]
 TLS_CERTIFICATES_PKI_RELATION_NAME = "tls-certificates-pki"
 KV_SECRET_PREFIX = "kv-creds-"
 VAULT_CHARM_APPROLE_SECRET_LABEL = "vault-approle-auth-details"
@@ -64,6 +69,7 @@ VAULT_SNAP_REVISION = "2181"
 VAULT_STORAGE_PATH = "/var/snap/vault/common/raft"
 VAULT_PKI_MOUNT = "charm-pki"
 VAULT_PKI_ROLE = "charm-pki"
+BACKUP_KEY_PREFIX = "vault-backup"
 
 
 def render_vault_config_file(
@@ -164,6 +170,7 @@ class VaultOperatorCharm(CharmBase):
         self.tls_certificates_pki = TLSCertificatesRequiresV3(
             self, TLS_CERTIFICATES_PKI_RELATION_NAME
         )
+        self.s3_requirer = S3Requirer(self, S3_RELATION_NAME)
         self.framework.observe(self.on.install, self._configure)
         self.framework.observe(self.on.collect_unit_status, self._on_collect_status)
         self.framework.observe(self.on.update_status, self._configure)
@@ -186,6 +193,7 @@ class VaultOperatorCharm(CharmBase):
             self.vault_pki.on.certificate_creation_request,
             self._on_vault_pki_certificate_creation_request,
         )
+        self.framework.observe(self.on.create_backup_action, self._on_create_backup_action)
 
     @contextmanager
     def temp_maintenance_status(self, message: str):
@@ -394,6 +402,102 @@ class VaultOperatorCharm(CharmBase):
         self._generate_pki_certificate_for_requirer(
             event.certificate_signing_request, event.relation_id
         )
+
+    def _on_create_backup_action(self, event: ActionEvent) -> None:
+        """Handle the create-backup action.
+
+        Creates a snapshot and stores it on S3 storage.
+        Outputs the ID of the backup to the user.
+
+        Args:
+            event: ActionEvent
+        """
+        if not self.unit.is_leader():
+            logger.error("Only leader unit can perform backup operations.")
+            event.fail(message="Only leader unit can perform backup operations.")
+            return
+
+        if not self._is_relation_created(S3_RELATION_NAME):
+            event.fail(message="Failed to perform backup. S3 relation not created.")
+            return
+
+        if missing_parameters:= self._get_missing_s3_parameters():
+            event.fail(message=f"Failed to perform backup. S3 parameters missing: {missing_parameters}")
+            return
+
+        s3_parameters = self._get_s3_parameters()
+
+        try:
+            s3 = S3(
+                access_key=s3_parameters["access-key"],
+                secret_key=s3_parameters["secret-key"],
+                endpoint=s3_parameters["endpoint"],
+                region=s3_parameters.get("region"),
+            )
+        except S3Error as e:
+            logger.error("Failed to create S3 session: %s", e)
+            event.fail(message="Failed to create S3 session.")
+            return
+
+        if not (s3.create_bucket(bucket_name=s3_parameters["bucket"])):
+            logger.error("Failed to create S3 bucket")
+            event.fail(message="Failed to create S3 bucket.")
+            return
+        backup_key = self._get_backup_key()
+        vault = self._get_vault_client()
+        if (
+            not vault
+            or not vault.is_api_available()
+            or not vault.is_initialized()
+            or vault.is_sealed()
+        ):
+            event.fail(message="Failed to initialize Vault client.")
+            return
+        response = vault.create_snapshot()
+        content_uploaded = s3.upload_content(
+            content=response.raw,
+            bucket_name=s3_parameters["bucket"],
+            key=backup_key,
+        )
+        if not content_uploaded:
+            logger.error("Failed to upload backup to S3 bucket")
+            event.fail(message="Failed to upload backup to S3 bucket.")
+            return
+        logger.info("Backup uploaded to S3 bucket %s", s3_parameters["bucket"])
+        event.set_results({"backup-id": backup_key})
+
+    def _get_backup_key(self) -> str:
+        """Return the backup key.
+
+        Returns:
+            str: The backup key
+        """
+        timestamp = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
+        return f"{BACKUP_KEY_PREFIX}-{self.model.name}-{timestamp}"
+
+    def _get_s3_parameters(self) -> Dict[str, str]:
+        """Retrieve S3 parameters from the S3 integrator relation.
+
+        Removes leading and trailing whitespaces from the parameters.
+
+        Returns:
+            Dict[str, str]: Dictionary of the S3 parameters.
+        """
+        s3_parameters = self.s3_requirer.get_s3_connection_info()
+        for key, value in s3_parameters.items():
+            if isinstance(value, str):
+                s3_parameters[key] = value.strip()
+        return s3_parameters
+
+
+    def _get_missing_s3_parameters(self) -> List[str]:
+        """Return the list of missing S3 parameters.
+
+        Returns:
+            List[str]: List of missing required S3 parameters.
+        """
+        s3_parameters = self.s3_requirer.get_s3_connection_info()
+        return [param for param in REQUIRED_S3_PARAMETERS if param not in s3_parameters]
 
     def _generate_kv_for_requirer(
             self,

--- a/src/s3_session.py
+++ b/src/s3_session.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""S3 helper class."""
+
+import logging
+from typing import IO, Optional, cast
+
+import boto3
+from botocore.config import Config
+from botocore.exceptions import BotoCoreError, ClientError
+from mypy_boto3_s3.literals import BucketLocationConstraintType
+from mypy_boto3_s3.service_resource import Bucket
+from mypy_boto3_s3.type_defs import CreateBucketConfigurationTypeDef
+
+logger = logging.getLogger(__name__)
+
+AWS_DEFAULT_REGION = "us-east-1"
+
+
+class S3Error(Exception):
+    """Base class for S3 errors."""
+
+    pass
+
+class S3:
+    """A class representing an S3 session allowing S3 operations."""
+
+    def __init__(
+        self,
+        access_key: str,
+        secret_key: str,
+        endpoint: str,
+        region: Optional[str] = AWS_DEFAULT_REGION,
+    ):
+        self.access_key = access_key
+        self.secret_key = secret_key
+        self.endpoint = endpoint
+        self.region = region
+        try:
+            self.session = boto3.session.Session(
+                aws_access_key_id=self.access_key,
+                aws_secret_access_key=self.secret_key,
+                region_name=region,
+            )
+            custom_config = Config(
+                retries={
+                    "max_attempts": 1,
+                },
+            )
+            self.s3 = self.session.resource("s3", endpoint_url=self.endpoint, config=custom_config)
+        except (ClientError, BotoCoreError, ValueError) as e:
+            raise S3Error(f"Error creating session: {e}")
+
+    def create_bucket(self, bucket_name: str) -> bool:
+        """Create S3 bucket.
+
+        If the bucket already exists, it will be skipped.
+
+        Args:
+            bucket_name: S3 bucket name to be created.
+
+        Returns:
+            bool: True if the bucket was created, False otherwise.
+        """
+        bucket = self.s3.Bucket(name=bucket_name)
+        if self._bucket_exists(bucket=bucket):
+            logger.info("Bucket %s already exists.", bucket_name)
+            return True
+        return self._create_bucket(bucket=bucket)
+
+
+    def _bucket_exists(self, bucket: Bucket) -> bool:
+        """Return whether the bucket exists."""
+        try:
+            bucket.meta.client.head_bucket(Bucket=bucket.name)
+        except ClientError:
+            return False
+        except BotoCoreError:
+            return False
+        return True
+
+    def _create_bucket(self, bucket: Bucket) -> bool:
+        """Create the S3 bucket."""
+        try:
+            if self.region == AWS_DEFAULT_REGION or self.region is None:
+                bucket.create()
+            else:
+                region_literal = cast(BucketLocationConstraintType, self.region)
+                create_bucket_configuration: CreateBucketConfigurationTypeDef = {
+                    "LocationConstraint": region_literal
+                }
+                bucket.create(CreateBucketConfiguration=create_bucket_configuration)
+
+            bucket.wait_until_exists()
+            return True
+        except (BotoCoreError, ClientError) as error:
+            logger.error(
+                "Couldn't create bucket named '%s' in region=%s. %s",
+                bucket.name,
+                self.region,
+                error,
+            )
+            return False
+
+
+    def upload_content(
+        self,
+        content: IO[bytes],
+        bucket_name: str,
+        key: str,
+    ) -> bool:
+        """Upload the provided contents to the provided S3 bucket.
+
+        Args:
+            content: File like object containing the content to upload.
+            bucket_name: S3 bucket name.
+            key: S3 object key.
+
+        Returns:
+            bool: True if the upload was successful, False otherwise.
+        """
+        try:
+            bucket = self.s3.Bucket(name=bucket_name)
+            bucket.upload_fileobj(Key=key, Fileobj=content)
+            return True
+        except (BotoCoreError, ClientError) as e:
+            logger.error("Error uploading content to bucket %s: %s", bucket_name, e)
+            return False

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -12,20 +12,26 @@ cachetools==5.3.3
     # via google-auth
 certifi==2024.2.2
     # via
+    #   -c requirements.txt
     #   kubernetes
     #   requests
 cffi==1.16.0
     # via
+    #   -c requirements.txt
     #   cryptography
     #   pynacl
 charset-normalizer==3.3.2
-    # via requests
+    # via
+    #   -c requirements.txt
+    #   requests
 codespell==2.2.6
     # via -r test-requirements.in
 coverage[toml]==7.4.4
     # via -r test-requirements.in
 cryptography==42.0.5
-    # via paramiko
+    # via
+    #   -c requirements.txt
+    #   paramiko
 decorator==5.1.1
     # via
     #   ipdb
@@ -35,19 +41,27 @@ executing==2.0.1
 google-auth==2.29.0
     # via kubernetes
 hvac==2.1.0
-    # via juju
+    # via
+    #   -c requirements.txt
+    #   juju
 idna==3.6
-    # via requests
+    # via
+    #   -c requirements.txt
+    #   requests
 iniconfig==2.0.0
-    # via pytest
+    # via
+    #   -c requirements.txt
+    #   pytest
 ipdb==0.13.13
     # via pytest-operator
-ipython==8.22.2
+ipython==8.23.0
     # via ipdb
 jedi==0.19.1
     # via ipython
 jinja2==3.1.3
-    # via pytest-operator
+    # via
+    #   -c requirements.txt
+    #   pytest-operator
 juju==3.4.0.0
     # via
     #   -r test-requirements.in
@@ -57,7 +71,9 @@ kubernetes==29.0.0
 macaroonbakery==1.3.4
     # via juju
 markupsafe==2.1.5
-    # via jinja2
+    # via
+    #   -c requirements.txt
+    #   jinja2
 matplotlib-inline==0.1.6
     # via ipython
 mypy-extensions==1.0.0
@@ -70,6 +86,7 @@ oauthlib==3.2.2
     #   requests-oauthlib
 packaging==24.0
     # via
+    #   -c requirements.txt
     #   juju
     #   pytest
 paramiko==3.4.0
@@ -79,10 +96,12 @@ parso==0.8.3
 pexpect==4.9.0
     # via ipython
 pluggy==1.4.0
-    # via pytest
+    # via
+    #   -c requirements.txt
+    #   pytest
 prompt-toolkit==3.0.43
     # via ipython
-protobuf==5.26.0
+protobuf==5.26.1
     # via macaroonbakery
 ptyprocess==0.7.0
     # via pexpect
@@ -95,8 +114,10 @@ pyasn1==0.6.0
     #   rsa
 pyasn1-modules==0.4.0
     # via google-auth
-pycparser==2.21
-    # via cffi
+pycparser==2.22
+    # via
+    #   -c requirements.txt
+    #   cffi
 pygments==2.17.2
     # via ipython
 pymacaroons==0.13.0
@@ -110,10 +131,11 @@ pyrfc3339==1.1
     # via
     #   juju
     #   macaroonbakery
-pyright==1.1.356
+pyright==1.1.357
     # via -r test-requirements.in
 pytest==8.1.1
     # via
+    #   -c requirements.txt
     #   -r test-requirements.in
     #   pytest-asyncio
     #   pytest-operator
@@ -122,16 +144,20 @@ pytest-asyncio==0.21.1
 pytest-operator==0.34.0
     # via -r test-requirements.in
 python-dateutil==2.9.0.post0
-    # via kubernetes
+    # via
+    #   -c requirements.txt
+    #   kubernetes
 pytz==2024.1
     # via pyrfc3339
 pyyaml==6.0.1
     # via
+    #   -c requirements.txt
     #   juju
     #   kubernetes
     #   pytest-operator
 requests==2.31.0
     # via
+    #   -c requirements.txt
     #   hvac
     #   kubernetes
     #   macaroonbakery
@@ -144,6 +170,7 @@ ruff==0.3.5
     # via -r test-requirements.in
 six==1.16.0
     # via
+    #   -c requirements.txt
     #   asttokens
     #   kubernetes
     #   macaroonbakery
@@ -158,17 +185,23 @@ traitlets==5.14.2
     #   ipython
     #   matplotlib-inline
 typing-extensions==4.10.0
-    # via typing-inspect
+    # via
+    #   -c requirements.txt
+    #   ipython
+    #   typing-inspect
 typing-inspect==0.9.0
     # via juju
 urllib3==2.2.1
     # via
+    #   -c requirements.txt
     #   kubernetes
     #   requests
 wcwidth==0.2.13
     # via prompt-toolkit
 websocket-client==1.7.0
-    # via kubernetes
+    # via
+    #   -c requirements.txt
+    #   kubernetes
 websockets==12.0
     # via juju
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from juju.unit import Unit
+
+
+async def get_leader_unit(model, application_name: str) -> Unit:
+    """Return the leader unit for the given application."""
+    for unit in model.units.values():
+        if unit.application == application_name and await unit.is_leader_from_status():
+            return unit
+    raise RuntimeError(f"Leader unit for `{application_name}` not found.")

--- a/tests/unit/test_s3_session.py
+++ b/tests/unit/test_s3_session.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import io
+import unittest
+from unittest.mock import Mock, patch
+
+import boto3
+from botocore.exceptions import ClientError
+from s3_session import S3, S3Error
+
+
+class TestS3(unittest.TestCase):
+    VALID_S3_PARAMETERS = {
+        "access-key": "ACCESS-KEY",
+        "secret-key": "SECRET-KEY",
+        "region": "REGION",
+        "endpoint": "http://ENDPOINT",
+    }
+
+    def test_given_valid_s3_parameters_when_create_s3_session_then_session_is_created(self):
+        s3 = S3(
+            access_key=self.VALID_S3_PARAMETERS["access-key"],
+            secret_key=self.VALID_S3_PARAMETERS["secret-key"],
+            region=self.VALID_S3_PARAMETERS["region"],
+            endpoint=self.VALID_S3_PARAMETERS["endpoint"],
+        )
+        self.assertIsInstance(s3.session, boto3.session.Session)
+
+    def test_given_invalid_endpoint_when_create_s3_session_then_valueerror_is_raised(self):
+        invalid_s3_parameters = {
+            "access-key": "ACCESS-KEY",
+            "secret-key": "SECRET-KEY",
+            "region": "REGION",
+            "endpoint": "invalid endpoint",
+        }
+        with self.assertRaises(S3Error):
+            S3(
+                access_key=invalid_s3_parameters["access-key"],
+                secret_key=invalid_s3_parameters["secret-key"],
+                region=invalid_s3_parameters["region"],
+                endpoint=invalid_s3_parameters["endpoint"],
+            )
+
+    @patch("boto3.session.Session")
+    def test_given_bucket_already_exists_when_create_bucket_then_bucket_not_created(
+        self,
+        patch_session,
+    ):
+        mock_resource = Mock()
+        mock_bucket = Mock()
+
+        patch_session.return_value.resource.return_value = mock_resource
+        mock_resource.Bucket.return_value = mock_bucket
+
+        s3 = S3(
+            access_key=self.VALID_S3_PARAMETERS["access-key"],
+            secret_key=self.VALID_S3_PARAMETERS["secret-key"],
+            region=self.VALID_S3_PARAMETERS["region"],
+            endpoint=self.VALID_S3_PARAMETERS["endpoint"],
+        )
+
+        s3.create_bucket(bucket_name="whatever-bucket")
+
+        patch_session.resource.Bucket.create.assert_not_called()
+
+    @patch("boto3.session.Session")
+    def test_given_bucket_not_created_when_create_bucket_then_bucket_created(
+        self,
+        patch_session,
+    ):
+        mock_resource = Mock()
+        mock_bucket = Mock()
+        mock_client = Mock()
+
+        patch_session.return_value.resource.return_value = mock_resource
+        mock_resource.Bucket.return_value = mock_bucket
+        mock_bucket.meta.client = mock_client
+
+        mock_client.head_bucket.side_effect = ClientError(
+            operation_name="NoSuchBucket",
+            error_response={"Error": {"Message": "Random bucket exists error message"}},
+        )
+
+        s3 = S3(
+            access_key=self.VALID_S3_PARAMETERS["access-key"],
+            secret_key=self.VALID_S3_PARAMETERS["secret-key"],
+            region=self.VALID_S3_PARAMETERS["region"],
+            endpoint=self.VALID_S3_PARAMETERS["endpoint"],
+        )
+
+        s3.create_bucket(bucket_name="whatever-bucket")
+
+        mock_bucket.create.assert_called_once()
+
+    @patch("boto3.session.Session")
+    def test_given_bucket_does_not_exist_when_upload_content_then_content_not_uploaded(
+        self,
+        patch_session,
+    ):
+        mock_resource = Mock()
+        mock_bucket = Mock()
+        mock_client = Mock()
+
+        patch_session.return_value.resource.return_value = mock_resource
+        mock_resource.Bucket.return_value = mock_bucket
+        mock_bucket.meta.client = mock_client
+
+        s3 = S3(
+            access_key=self.VALID_S3_PARAMETERS["access-key"],
+            secret_key=self.VALID_S3_PARAMETERS["secret-key"],
+            region=self.VALID_S3_PARAMETERS["region"],
+            endpoint=self.VALID_S3_PARAMETERS["endpoint"],
+        )
+
+        mock_bucket.upload_fileobj.side_effect = ClientError(
+            operation_name="NoSuchBucket",
+            error_response={"Error": {"Message": "Random bucket exists error message"}},
+        )
+        self.assertFalse(
+            s3.upload_content(
+                bucket_name="whatever-bucket",
+                content=io.BytesIO(b"whatever content"),
+                key="whatever key",
+            )
+        )
+
+    @patch("boto3.session.Session", new=Mock)
+    def test_given_bucket_exists_when_upload_content_then_content_uploaded(self):
+        s3 = S3(
+            access_key=self.VALID_S3_PARAMETERS["access-key"],
+            secret_key=self.VALID_S3_PARAMETERS["secret-key"],
+            region=self.VALID_S3_PARAMETERS["region"],
+            endpoint=self.VALID_S3_PARAMETERS["endpoint"],
+        )
+
+        self.assertTrue(
+            s3.upload_content(
+                bucket_name="whatever-bucket",
+                content=io.BytesIO(b"whatever content"),
+                key="whatever key",
+            )
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]integration_test_path}
 
 [testenv]
 set_env =
-    PYTHONPATH = {tox_root}/lib:{[vars]src_path}
+    PYTHONPATH = {toxinidir}:{tox_root}/lib:{[vars]src_path}
     PYTHONBREAKPOINT=pdb.set_trace
     PY_COLORS=1
 deps =


### PR DESCRIPTION
# Description

Implement raft backup action using the `s3` charm relation interface.

## Usage

```
juju deploy s3-provider
juju integrate vault:s3-parameters <s3 provider>
juju run vault/leader create-backup
```

## Notes

### S3 Session helpers

The `s3_session` implementation is slightly different from the k8s version of the charm here:
- We don't bubble up exceptions from boto3 and use custom exceptions instead.
- We use typing coming from `boto3-stubs`
- We implement small private helpers (`_bucket_exists`, `_create_bucket`)

We likely want to combine this code into a charm library and have this imported in the two versions of the charm, I didn't want to impact the ongoing efforts in the k8s charm at that moment and decided against it for the moment.

### Integration tests

The integration tests here don't validate end-to-end s3 backup because there is no minio machine charm or any other machine charm that supports the s3 charm relation interface. So we simply validate that the `create-backup` action fails, as expected with the bad endpoint we provide it. This is likely something we want to improve in the future as the s3 situation on machine charms improve.


### Restore from a backup

`restore` and `list` backup actions will be implemented in independent PR's to keep PR reviewable, this one was large enough as it is.

## Reference

- https://developer.hashicorp.com/vault/tutorials/standard-procedures/sop-backup


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
