### PR TITLE
feat: implement `list-backups` action

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -16,3 +16,7 @@ create-backup:
   description: >-
     Creates a snapshot of the Raft backend and saves it to the S3 storage.
     Returns backup ID.
+
+list-backups:
+  description: >-
+    Lists all available backups.

--- a/src/charm.py
+++ b/src/charm.py
@@ -500,9 +500,9 @@ class VaultOperatorCharm(CharmBase):
                 endpoint=s3_parameters["endpoint"],
                 region=s3_parameters.get("region"),
             )
-        except S3Error:
+        except S3Error as e:
             event.fail(message="Failed to create S3 session.")
-            logger.error("Failed to run list-backups action - Failed to create S3 session.")
+            logger.error("Failed to run list-backups action - %s", e)
             return
 
         try:


### PR DESCRIPTION
# Description

Implement raft `list-backups` action using the `s3` charm relation interface. This is a follow-up to #108 .

## Usage

```
juju deploy s3-provider
juju integrate vault:s3-parameters <s3 provider>
juju run vault/leader list-backups
```

## Notes

### Integration tests

The integration tests here don't validate end-to-end s3 backup because there is no minio machine charm or any other machine charm that supports the s3 charm relation interface. So we simply validate that the `list-backups` action fails, as expected with the bad endpoint we provide it. This is likely something we want to improve in the future as the s3 situation on machine charms improve.

### Restore from a backup

The `restore` backup action will be implemented in independent PR's to keep PR reviewable, this one was large enough as it is.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
