### PR TITLE
fix: use latest version of juju secret

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -741,7 +741,7 @@ class VaultOperatorCharm(CharmBase):
                 content={"role-id": role_id, "role-secret-id": role_secret_id},
                 label=juju_secret_label,
             )
-        credentials = secret.get_content()
+        credentials = secret.get_content(refresh=True)
         credentials["role-secret-id"] = role_secret_id
         secret.set_content(credentials)
         return secret
@@ -940,7 +940,7 @@ class VaultOperatorCharm(CharmBase):
         if not self._pki_csr_secret_set():
             raise RuntimeError("PKI CSR secret not set.")
         secret = self.model.get_secret(label=VAULT_PKI_CSR_SECRET_LABEL)
-        return secret.get_content()["csr"]
+        return secret.get_content(refresh=True)["csr"]
 
     def _pki_csr_secret_set(self) -> bool:
         """Return whether PKI CSR secret is stored."""

--- a/tests/integration/vault_kv_requirer_operator/src/charm.py
+++ b/tests/integration/vault_kv_requirer_operator/src/charm.py
@@ -72,7 +72,7 @@ class VaultKVRequirerCharm(CharmBase):
             return
         unit_credentials = self.vault_kv.get_unit_credentials(relation)
         secret = self.model.get_secret(id=unit_credentials)
-        secret_content = secret.get_content()
+        secret_content = secret.get_content(refresh=True)
         juju_secret_content = {
             "vault-url": vault_url,
             "mount": mount,
@@ -101,7 +101,7 @@ class VaultKVRequirerCharm(CharmBase):
         except SecretNotFoundError:
             event.fail("Vault KV secret not found")
             return
-        secret_content = secret.get_content()
+        secret_content = secret.get_content(refresh=True)
         mount = secret_content["mount"]
         ca_certificate_path = self._get_ca_cert_location_in_charm()
         if ca_certificate_path is None:
@@ -128,7 +128,7 @@ class VaultKVRequirerCharm(CharmBase):
         except SecretNotFoundError:
             event.fail("Vault KV secret not found")
             return
-        secret_content = secret.get_content()
+        secret_content = secret.get_content(refresh=True)
         mount = secret_content["mount"]
         ca_certificate_path = self._get_ca_cert_location_in_charm()
         if ca_certificate_path is None:
@@ -153,7 +153,7 @@ class VaultKVRequirerCharm(CharmBase):
     def get_nonce(self) -> str:
         """Get the nonce from the secret."""
         secret = self.model.get_secret(label=NONCE_SECRET_LABEL)
-        return secret.get_content()["nonce"]
+        return secret.get_content(refresh=True)["nonce"]
 
     def _get_ca_cert_location_in_charm(self) -> Optional[Path]:
         """Return the CA certificate location in the charm (not in the workload).

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -469,7 +469,7 @@ class TestCharm(unittest.TestCase):
 
         secret_content = self.harness.model.get_secret(
             label=VAULT_CHARM_APPROLE_SECRET_LABEL
-        ).get_content()
+        ).get_content(refresh=True)
 
         assert secret_content["role-id"] == "approle_id"
         assert secret_content["secret-id"] == "secret_id"


### PR DESCRIPTION
# Description

We refresh the juju secret when checking its content making sure we are reading its latest value instead of an older one.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
