### PR TITLE
chore: Adds action result for authorise charm action

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -257,6 +257,7 @@ class VaultOperatorCharm(CharmBase):
             )
             vault_secret_id = vault.generate_role_secret_id(name="charm")
             self._create_approle_secret(role_id, vault_secret_id)
+            event.set_results({"result": "Charm authorized successfully."})
         except VaultClientError as e:
             logger.exception("Vault returned an error while authorizing the charm")
             event.fail(f"Vault returned an error while authorizing the charm: {str(e)}")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -470,7 +470,7 @@ class TestCharm(unittest.TestCase):
             },
         )
 
-        self.harness.run_action("authorize-charm", {"token": "test-token"})
+        action_result = self.harness.run_action("authorize-charm", {"token": "test-token"}).results
 
         # Assertions
         self.mock_vault.authenticate.assert_called_once_with(Token("test-token"))
@@ -492,6 +492,7 @@ class TestCharm(unittest.TestCase):
 
         assert secret_content["role-id"] == "approle_id"
         assert secret_content["secret-id"] == "secret_id"
+        assert action_result["result"] == "Charm authorized successfully."
 
     @patch("charm.get_common_name_from_certificate", new=Mock)
     @patch(f"{TLS_CERTIFICATES_LIB_PATH}.TLSCertificatesRequiresV3.request_certificate_creation")


### PR DESCRIPTION
# Description

Currently there is no output for the authorise-charm action when it is successful.
I think it is better to have a clear feedback when the action succeeds especially because some Juju versions fail to show failure messages.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
