### PR TITLE
feat: Adds Prometheus alert rules

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -71,6 +71,8 @@ VAULT_STORAGE_PATH = "/var/snap/vault/common/raft"
 VAULT_PKI_MOUNT = "charm-pki"
 VAULT_PKI_ROLE = "charm-pki"
 BACKUP_KEY_PREFIX = "vault-backup"
+LOGS_ALERT_RULES_PATH = "./src/loki_alert_rules"
+METRICS_ALERT_RULES_PATH = "./src/prometheus_alert_rules"
 
 
 def render_vault_config_file(
@@ -157,6 +159,8 @@ class VaultOperatorCharm(CharmBase):
             ],
             scrape_configs=self.generate_vault_scrape_configs,
             dashboard_dirs=["./src/grafana_dashboards"],
+            logs_rules_dir=LOGS_ALERT_RULES_PATH,
+            metrics_rules_dir=METRICS_ALERT_RULES_PATH
         )
         self.tls = VaultTLSManager(
             charm=self,

--- a/src/charm.py
+++ b/src/charm.py
@@ -71,7 +71,6 @@ VAULT_STORAGE_PATH = "/var/snap/vault/common/raft"
 VAULT_PKI_MOUNT = "charm-pki"
 VAULT_PKI_ROLE = "charm-pki"
 BACKUP_KEY_PREFIX = "vault-backup"
-LOGS_ALERT_RULES_PATH = "./src/loki_alert_rules"
 METRICS_ALERT_RULES_PATH = "./src/prometheus_alert_rules"
 
 
@@ -159,7 +158,6 @@ class VaultOperatorCharm(CharmBase):
             ],
             scrape_configs=self.generate_vault_scrape_configs,
             dashboard_dirs=["./src/grafana_dashboards"],
-            logs_rules_dir=LOGS_ALERT_RULES_PATH,
             metrics_rules_dir=METRICS_ALERT_RULES_PATH
         )
         self.tls = VaultTLSManager(

--- a/src/loki_alert_rules/error_logs_found.rule
+++ b/src/loki_alert_rules/error_logs_found.rule
@@ -1,0 +1,7 @@
+alert: ErrorLevelLogsFound
+expr: rate({%%juju_topology%%} |= "level=error"[1m]) > 0
+for: 1m
+labels:
+  severity: critical
+annotations:
+  summary: error level logs found.

--- a/src/loki_alert_rules/error_logs_found.rule
+++ b/src/loki_alert_rules/error_logs_found.rule
@@ -1,7 +1,0 @@
-alert: ErrorLevelLogsFound
-expr: rate({%%juju_topology%%} |= "vaultd" |= "[ERROR]"[1m]) >0
-for: 1m
-labels:
-  severity: critical
-annotations:
-  summary: Vault error level logs found.

--- a/src/loki_alert_rules/error_logs_found.rule
+++ b/src/loki_alert_rules/error_logs_found.rule
@@ -1,7 +1,7 @@
 alert: ErrorLevelLogsFound
-expr: rate({%%juju_topology%%} |= "level=error"[1m]) > 0
+expr: rate({%%juju_topology%%} |= "vaultd" |= "[ERROR]"[1m]) >0
 for: 1m
 labels:
   severity: critical
 annotations:
-  summary: error level logs found.
+  summary: Vault error level logs found.

--- a/src/prometheus_alert_rules/failure_tolerance.rule
+++ b/src/prometheus_alert_rules/failure_tolerance.rule
@@ -1,0 +1,8 @@
+alert: VaultFailureToleranceRule
+expr: vault_autopilot_failure_tolerance <= 1
+for: 2m
+labels:
+    severity: critical
+annotations:
+    summary: "Vault cluster has low failure tolerance and the quorum could be lost."
+    description: "Vault autopilot reports that the cluster has 1 or fewer extra healthy nodes in excess of quorum."

--- a/src/prometheus_alert_rules/leader_last_contact.rule
+++ b/src/prometheus_alert_rules/leader_last_contact.rule
@@ -1,0 +1,8 @@
+alert: VaultClusterLeaderLastContactRule
+expr: vault_raft_leader_lastContact{quantile="0.9"} > 200
+for: 1m
+labels:
+    severity: critical
+annotations:
+    summary: "High delays in leader contacting followers"
+    description: "The leader has frequently failed to contact followers within 200 ms in the last one minute"

--- a/src/prometheus_alert_rules/leadership_setup_failure.rule
+++ b/src/prometheus_alert_rules/leadership_setup_failure.rule
@@ -1,0 +1,7 @@
+alert: VaultClusterLeadershipSetupFailureRule
+expr: vault_core_leadership_setup_failed > 500
+labels:
+    severity: critical
+annotations:
+    summary: "Spike in delay during Vault leadership setup"
+    description: "Leadership setup took longer than 500ms"

--- a/src/prometheus_alert_rules/vault_sealed.rule
+++ b/src/prometheus_alert_rules/vault_sealed.rule
@@ -1,5 +1,5 @@
 alert: VaultSealedRule
-expr: vault_core_unsealed == 0
+expr: vault_core_unsealed{cluster!=""} == 0
 for: 0m
 labels:
     severity: critical

--- a/src/prometheus_alert_rules/vault_sealed.rule
+++ b/src/prometheus_alert_rules/vault_sealed.rule
@@ -1,0 +1,8 @@
+alert: VaultSealedRule
+expr: vault_core_unsealed == 0
+for: 0m
+labels:
+    severity: critical
+annotations:
+    summary: "Vault is sealed"
+    description: "Vault instance is sealed on {{ $labels.instance }}\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"


### PR DESCRIPTION
# Description

Adds Prometheus alert rules following spec TE071.

To test deploy the charm from this branch and follow the [guide on how to integrate with COS](https://charmhub.io/vault/docs/h-integrate-with-cos?channel=1.15/beta), go to the alerts tabs in Grafana and then:
- To test the vault sealed rule, seal and unseal vault and observe the alert firing
- To test the leader last contact rule, reduce the threshold to something very small, maybe 5 ms and observe the alert firing
- To test the failure tolerance rule scale vault up to 3 units then back to 2 units and observe the alert firing
- I couldn't find a way to simulate leadership setup failure

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
