### PR TITLE
fix: Update intermediate CA and PKI role when common_name is changed

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -101,6 +101,7 @@ config:
       description: |
         The common name that will be used by Vault as an intermediate CA. This will only be used when the charm is 
         configured to use a Vault PKI backend through the `vault-pki` relation.
+        The charm will only issue certificates for the subdomains under the `common_name` specified.
 
 actions:
   authorize-charm:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -538,12 +538,66 @@ class TestCharm(unittest.TestCase):
             certificate_signing_request=csr.encode(), is_ca=True
         )
 
+    @patch("charm.config_file_content_matches", new=Mock())
+    @patch("charm.get_common_name_from_certificate", new=Mock)
+    @patch(f"{TLS_CERTIFICATES_LIB_PATH}.TLSCertificatesRequiresV3.request_certificate_creation")
+    @patch("ops.model.Model.get_binding")
+    def test_given_vault_pki_configured_when_common_name_is_changed_then_new_certificate_request_is_made(  # noqa: E501
+        self,
+        patch_get_binding,
+        patch_request_certificate_creation,
+    ):
+        self._set_peer_relation()
+        patch_get_binding.return_value = MockBinding(
+            bind_address="1.2.1.2", ingress_address="2.3.2.3"
+        )
+        csr = "some csr content"
+        self.harness.charm.app.add_secret(
+            {"role-id": "role-id", "secret-id": "secret-id"},
+            label=VAULT_CHARM_APPROLE_SECRET_LABEL,
+        )
+        self.mock_vault.configure_mock(
+            spec=Vault,
+            **{
+                "is_initialized.return_value": True,
+                "is_api_available.return_value": True,
+                "is_sealed.return_value": False,
+                "get_intermediate_ca.return_value": "vault",
+                "generate_pki_intermediate_ca_csr.return_value": csr,
+            },
+        )
+        self.harness.update_config({"common_name": "vault"})
+        self.harness.set_leader(is_leader=True)
+        relation_id = self.harness.add_relation(
+            relation_name=TLS_CERTIFICATES_PKI_RELATION_NAME, remote_app="tls-provider"
+        )
+
+        self.harness.add_relation_unit(relation_id, "tls-provider/0")
+
+        self.mock_vault.enable_secrets_engine.assert_called_with(SecretsBackend.PKI, "charm-pki")
+        self.mock_vault.generate_pki_intermediate_ca_csr.assert_called_with(
+            mount="charm-pki", common_name="vault"
+        )
+        patch_request_certificate_creation.assert_called_with(
+            certificate_signing_request=csr.encode(), is_ca=True
+        )
+
+        self.harness.update_config({"common_name": "new_common_name"})
+        self.mock_vault.generate_pki_intermediate_ca_csr.assert_called_with(
+            mount="charm-pki", common_name="new_common_name"
+        )
+        patch_request_certificate_creation.assert_called_with(
+            certificate_signing_request=csr.encode(), is_ca=True
+        )
+
+    @patch("charm.get_common_name_from_certificate")
     @patch("ops.model.Model.get_binding")
     @patch(f"{TLS_CERTIFICATES_LIB_PATH}.TLSCertificatesRequiresV3.get_assigned_certificates")
     def test_given_vault_is_available_when_pki_certificate_is_available_then_certificate_added_to_vault_pki(  # noqa: E501
         self,
         patch_get_assigned_certificates,
         patch_get_binding,
+        patch_get_common_name_from_certificate,
     ):
         peer_relation_id = self._set_peer_relation()
         patch_get_binding.return_value = MockBinding(
@@ -561,6 +615,7 @@ class TestCharm(unittest.TestCase):
                 "is_sealed.return_value": False,
                 "is_intermediate_ca_set.return_value": False,
                 "is_pki_role_created.return_value": False,
+                "is_common_name_allowed_in_pki_role.return_value": False,
             },
         )
 
@@ -568,7 +623,9 @@ class TestCharm(unittest.TestCase):
         certificate = "some certificate"
         ca = "some ca"
         chain = [ca]
-        self.harness.update_config({"common_name": "vault"})
+        common_name = "vault"
+        patch_get_common_name_from_certificate.return_value = common_name
+        self.harness.update_config({"common_name": common_name})
         self.harness.set_leader(is_leader=True)
 
         self._set_csr_secret_in_peer_relation(relation_id=peer_relation_id, csr="some csr content")
@@ -601,8 +658,94 @@ class TestCharm(unittest.TestCase):
             certificate=certificate,
             mount="charm-pki",
         )
-        self.mock_vault.create_pki_charm_role.assert_called_with(
+        self.mock_vault.create_or_update_pki_charm_role.assert_called_with(
             allowed_domains="vault", mount="charm-pki", role="charm-pki"
+        )
+
+    @patch("charm.config_file_content_matches", new=Mock())
+    @patch("charm.get_common_name_from_certificate")
+    @patch("ops.model.Model.get_binding")
+    @patch(f"{TLS_CERTIFICATES_LIB_PATH}.TLSCertificatesRequiresV3.get_assigned_certificates")
+    def test_given_vault_pki_configured_when_common_name_is_changed_then_new_certificate_added_to_vault_pki(  # noqa: E501
+        self,
+        patch_get_assigned_certificates,
+        patch_get_binding,
+        patch_get_common_name_from_certificate,
+    ):
+        peer_relation_id = self._set_peer_relation()
+        patch_get_binding.return_value = MockBinding(
+            bind_address="1.2.1.2", ingress_address="2.3.2.3"
+        )
+        self.harness.charm.app.add_secret(
+            {"role-id": "role-id", "secret-id": "secret-id"},
+            label=VAULT_CHARM_APPROLE_SECRET_LABEL,
+        )
+        csr = "some csr content"
+        certificate = "some certificate"
+        ca = "some ca"
+        chain = [ca]
+        common_name = "vault"
+        self.mock_vault.configure_mock(
+            spec=Vault,
+            **{
+                "is_initialized.return_value": True,
+                "is_api_available.return_value": True,
+                "is_sealed.return_value": False,
+                "is_intermediate_ca_set.return_value": False,
+                "is_pki_role_created.return_value": False,
+                "is_common_name_allowed_in_pki_role.return_value": False,
+                "generate_pki_intermediate_ca_csr.return_value": csr,
+            },
+        )
+
+        patch_get_common_name_from_certificate.return_value = common_name
+        self.harness.update_config({"common_name": common_name})
+        self.harness.set_leader(is_leader=True)
+
+        self._set_csr_secret_in_peer_relation(relation_id=peer_relation_id, csr="some csr content")
+        event = CertificateAvailableEvent(
+            handle=Mock(),
+            certificate=certificate,
+            certificate_signing_request=csr,
+            ca=ca,
+            chain=chain,
+        )
+        relation_id = self.harness.add_relation(
+            relation_name=TLS_CERTIFICATES_PKI_RELATION_NAME, remote_app="tls-provider"
+        )
+        patch_get_assigned_certificates.return_value = [
+            ProviderCertificate(
+                relation_id=relation_id,
+                application_name="tls-provider",
+                csr=csr,
+                certificate=certificate,
+                ca=ca,
+                chain=chain,
+                revoked=False,
+                expiry_time=datetime.now(timezone.utc),
+            )
+        ]
+
+        self.harness.charm._on_tls_certificate_pki_certificate_available(event)
+
+        self.mock_vault.set_pki_intermediate_ca_certificate.assert_called_with(
+            certificate=certificate,
+            mount="charm-pki",
+        )
+        self.mock_vault.create_or_update_pki_charm_role.assert_called_with(
+            allowed_domains="vault", mount="charm-pki", role="charm-pki"
+        )
+
+        self.harness.update_config({"common_name": "new_common_name"})
+
+        self.harness.charm._on_tls_certificate_pki_certificate_available(event)
+
+        self.mock_vault.set_pki_intermediate_ca_certificate.assert_called_with(
+            certificate=certificate,
+            mount="charm-pki",
+        )
+        self.mock_vault.create_or_update_pki_charm_role.assert_called_with(
+            allowed_domains="new_common_name", mount="charm-pki", role="charm-pki"
         )
 
     @patch("ops.model.Model.get_binding")


### PR DESCRIPTION
# Description


This PR introduces the same changes as https://github.com/canonical/vault-k8s-operator/pull/377 that was merged in the k8s charm.
- Fetches the latest vault_client lib
- Fixes: https://github.com/canonical/vault-k8s-operator/issues/367 in the charm code
  - When the common name is changed a new CSR will be generated to get a new intermediate CA that will replace the old one and the pki role will be updated too.
- Adds unit tests

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
