### PR TITLE
chore: Fetches latest vault client lib and applies required changes

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -949,6 +949,11 @@ class VaultOperatorCharm(CharmBase):
                 mount=VAULT_PKI_MOUNT,
                 role=VAULT_PKI_ROLE,
             )
+        # Can run only after the first issuer has been actually created.
+        try:
+            vault.make_latest_pki_issuer_default(mount=VAULT_PKI_MOUNT)
+        except VaultClientError as e:
+            logger.error("Failed to make latest issuer default: %s", e)
 
     def _get_pki_intermediate_ca_certificate(self) -> Optional[str]:
         """Return the PKI CA certificate provided by the TLS provider.

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -33,6 +33,9 @@ S3_INTEGRATOR_APPLICATION_NAME = "s3-integrator"
 VAULT_KV_LIB_DIR = "lib/charms/vault_k8s/v0/vault_kv.py"
 VAULT_KV_REQUIRER_CHARM_DIR = "tests/integration/vault_kv_requirer_operator"
 
+MATCHING_COMMON_NAME = "example.com"
+UNMATCHING_COMMON_NAME = "unmatching-the-requirer.com"
+
 
 async def run_get_ca_certificate_action(ops_test: OpsTest, timeout: int = 60) -> dict:
     """Run the `get-certificate` on the `self-signed-certificates` unit.
@@ -122,7 +125,7 @@ async def deploy_requiring_charms(ops_test: OpsTest, deploy_vault: None, request
         application_name=VAULT_PKI_REQUIRER_APPLICATION_NAME,
         channel="stable",
         num_units=1,
-        config={"common_name": "test.example.com"},
+        config={"common_name": f"test.{MATCHING_COMMON_NAME}"},
     )
     deploy_grafana_agent = ops_test.model.deploy(
         GRAFANA_AGENT_APPLICATION_NAME,
@@ -576,7 +579,7 @@ async def test_given_tls_certificates_pki_relation_when_integrate_then_status_is
     assert ops_test.model
     vault_app = ops_test.model.applications[APP_NAME]
     assert vault_app
-    common_name = "unmatching-the-requirer.com"
+    common_name = UNMATCHING_COMMON_NAME
     common_name_config = {
         "common_name": common_name,
     }
@@ -620,7 +623,7 @@ async def test_given_vault_pki_relation_and_unmatching_common_name_when_integrat
         unit_address=leader_unit_address,
         mount="charm-pki",
     )
-    assert current_issuers_common_name == "unmatching-the-requirer.com"
+    assert current_issuers_common_name == UNMATCHING_COMMON_NAME
 
     action_output = await run_get_certificate_action(ops_test)
     assert action_output.get("certificate") is None
@@ -633,7 +636,7 @@ async def test_given_vault_pki_relation_and_matching_common_name_configured_when
     assert ops_test.model
     vault_app = ops_test.model.applications[APP_NAME]
     assert vault_app
-    common_name = "example.com"
+    common_name = MATCHING_COMMON_NAME
     common_name_config = {
         "common_name": common_name,
     }

--- a/tests/integration/vault.py
+++ b/tests/integration/vault.py
@@ -20,9 +20,12 @@ VAULT_STATUS_NOT_INITIALIZED = 501
 
 
 class Vault:
-    def __init__(self, url: str, ca_file_location: str, token: Optional[str] = None):
+    def __init__(
+        self, url: str, ca_file_location: Optional[str] = None, token: Optional[str] = None
+    ):
         self.url = url
-        self.client = hvac.Client(url=self.url, verify=abspath(ca_file_location))
+        verify = abspath(ca_file_location) if ca_file_location else False
+        self.client = hvac.Client(url=self.url, verify=verify)
         if token:
             self.client.token = token
 


### PR DESCRIPTION
# Description

Fetches the changes made to the vault client lib in [this PR](https://github.com/canonical/vault-k8s-operator/pull/386) and applies required change like in that PR and adds tests.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
