### PR TITLE
style: Format using `ruff`

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -25,6 +25,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         help="Path to the KV requirer charm",
     )
 
+
 def pytest_configure(config: pytest.Config) -> None:
     """Validate the options provided by the user.
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -65,6 +65,7 @@ async def get_leader(app: Application) -> Unit | None:
             return unit
     return None
 
+
 async def run_get_certificate_action(ops_test: OpsTest) -> dict:
     """Run `get-certificate` on the `tls-requirer-requirer/0` unit.
 
@@ -83,6 +84,7 @@ async def run_get_certificate_action(ops_test: OpsTest) -> dict:
     action_output = await ops_test.model.get_action_output(action_uuid=action.entity_id, wait=30)
     return action_output
 
+
 async def wait_for_certificate_to_be_provided(ops_test: OpsTest) -> None:
     start_time = time.time()
     timeout = 300
@@ -92,6 +94,7 @@ async def wait_for_certificate_to_be_provided(ops_test: OpsTest) -> None:
             return
         time.sleep(10)
     raise TimeoutError("Timed out waiting for certificate to be provided.")
+
 
 @pytest.fixture(scope="module")
 async def deploy_vault(ops_test: OpsTest, request) -> None:
@@ -134,11 +137,11 @@ async def deploy_requiring_charms(ops_test: OpsTest, deploy_vault: None, request
         channel="stable",
     )
     deploy_s3_integrator = ops_test.model.deploy(
-            "s3-integrator",
-            application_name=S3_INTEGRATOR_APPLICATION_NAME,
-            trust=True,
-            channel="stable",
-        )
+        "s3-integrator",
+        application_name=S3_INTEGRATOR_APPLICATION_NAME,
+        trust=True,
+        channel="stable",
+    )
     deployed_apps = [
         SELF_SIGNED_CERTIFICATES_APPLICATION_NAME,
         VAULT_KV_REQUIRER_APPLICATION_NAME,
@@ -154,19 +157,16 @@ async def deploy_requiring_charms(ops_test: OpsTest, deploy_vault: None, request
         deploy_s3_integrator,
     )
     await ops_test.model.wait_for_idle(
-        apps=[
-            SELF_SIGNED_CERTIFICATES_APPLICATION_NAME,
-            VAULT_PKI_REQUIRER_APPLICATION_NAME
-            ],
+        apps=[SELF_SIGNED_CERTIFICATES_APPLICATION_NAME, VAULT_PKI_REQUIRER_APPLICATION_NAME],
         status="active",
         timeout=1000,
     )
     await ops_test.model.wait_for_idle(
-            apps=[S3_INTEGRATOR_APPLICATION_NAME],
-            status="blocked",
-            timeout=1000,
-            wait_for_exact_units=1,
-        )
+        apps=[S3_INTEGRATOR_APPLICATION_NAME],
+        status="blocked",
+        timeout=1000,
+        wait_for_exact_units=1,
+    )
     yield
     remove_coroutines = [
         ops_test.model.remove_application(app_name=app_name) for app_name in deployed_apps
@@ -227,6 +227,7 @@ async def run_s3_integrator_sync_credentials_action(
         action_uuid=sync_credentials_action.entity_id, wait=120
     )
 
+
 async def run_create_backup_action(ops_test: OpsTest) -> dict:
     """Run the `create-backup` action on the `vault-k8s` leader unit.
 
@@ -244,6 +245,7 @@ async def run_create_backup_action(ops_test: OpsTest) -> dict:
         action_uuid=create_backup_action.entity_id, wait=120
     )
 
+
 async def run_list_backups_action(ops_test: OpsTest) -> dict:
     """Run the `list-backups` action on the `vault-k8s` leader unit.
 
@@ -260,6 +262,7 @@ async def run_list_backups_action(ops_test: OpsTest) -> dict:
     return await ops_test.model.get_action_output(
         action_uuid=list_backups_action.entity_id, wait=120
     )
+
 
 async def run_restore_backup_action(ops_test: OpsTest, backup_id: str) -> dict:
     """Run the `restore-backup` action on the `vault-k8s` leader unit.
@@ -279,6 +282,7 @@ async def run_restore_backup_action(ops_test: OpsTest, backup_id: str) -> dict:
     return await ops_test.model.get_action_output(
         action_uuid=restore_backup_action.entity_id, wait=120
     )
+
 
 @pytest.fixture(scope="module")
 async def initialize_vault(ops_test: OpsTest, deploy_vault: None) -> Tuple[str, str]:
@@ -305,7 +309,6 @@ async def initialize_vault(ops_test: OpsTest, deploy_vault: None) -> Tuple[str, 
     return root_token, unseal_key
 
 
-
 async def authorize_charm(ops_test: OpsTest, root_token: str) -> Any | Dict:
     """Authorize the charm to interact with Vault.
 
@@ -325,6 +328,7 @@ async def authorize_charm(ops_test: OpsTest, root_token: str) -> Any | Dict:
     )
     return result
 
+
 async def get_leader_unit_address(ops_test: OpsTest) -> Optional[str]:
     """Get the address of the leader unit.
 
@@ -337,6 +341,7 @@ async def get_leader_unit_address(ops_test: OpsTest) -> Optional[str]:
     leader = await get_leader(app)
     assert leader
     return leader.public_address
+
 
 @pytest.mark.abort_on_fail
 async def test_given_charm_build_when_deploy_then_status_blocked(
@@ -391,6 +396,7 @@ async def test_given_certificates_provider_is_related_when_vault_status_checked_
     vault = Vault(url=vault_url, ca_file_location=ca_file_location)
     assert not vault.is_initialized()
 
+
 @pytest.mark.abort_on_fail
 async def test_given_charm_deployed_when_vault_initialized_and_unsealed_and_authorized_then_status_is_active(  # noqa: E501
     ops_test: OpsTest, deploy_requiring_charms: None, initialize_vault: Tuple[str, str]
@@ -437,6 +443,7 @@ async def test_given_charm_deployed_when_vault_initialized_and_unsealed_and_auth
         )
     vault.wait_for_raft_nodes(expected_num_nodes=NUM_VAULT_UNITS)
 
+
 @pytest.mark.abort_on_fail
 async def test_given_application_is_deployed_when_scale_up_then_status_is_active(
     ops_test: OpsTest,
@@ -452,11 +459,11 @@ async def test_given_application_is_deployed_when_scale_up_then_status_is_active
 
     async with ops_test.fast_forward(fast_interval="10s"):
         await ops_test.model.wait_for_idle(
-                apps=[APP_NAME],
-                status="blocked",
-                timeout=1000,
-                wait_for_at_least_units=1,
-            )
+            apps=[APP_NAME],
+            status="blocked",
+            timeout=1000,
+            wait_for_at_least_units=1,
+        )
 
     action_output = await run_get_ca_certificate_action(ops_test)
     ca_certificate = action_output["ca-certificate"]
@@ -482,6 +489,7 @@ async def test_given_application_is_deployed_when_scale_up_then_status_is_active
         )
 
     vault.wait_for_raft_nodes(expected_num_nodes=num_units)
+
 
 @pytest.mark.abort_on_fail
 async def test_given_application_is_deployed_when_scale_down_then_status_is_active(
@@ -510,6 +518,7 @@ async def test_given_application_is_deployed_when_scale_down_then_status_is_acti
     # because the Vault API address is often not available during the
     # unit removal.
 
+
 @pytest.mark.abort_on_fail
 async def test_given_grafana_agent_deployed_when_relate_to_grafana_agent_then_status_is_active(
     ops_test: OpsTest, deploy_requiring_charms: None
@@ -526,6 +535,7 @@ async def test_given_grafana_agent_deployed_when_relate_to_grafana_agent_then_st
             status="active",
         )
 
+
 @pytest.mark.abort_on_fail
 async def test_given_vault_kv_requirer_deployed_when_vault_kv_relation_created_then_status_is_active(  # noqa: E501
     ops_test: OpsTest, deploy_requiring_charms: None
@@ -541,6 +551,7 @@ async def test_given_vault_kv_requirer_deployed_when_vault_kv_relation_created_t
             status="active",
             timeout=1000,
         )
+
 
 @pytest.mark.abort_on_fail
 async def test_given_vault_kv_requirer_related_when_create_secret_then_secret_is_created(
@@ -602,18 +613,18 @@ async def test_given_vault_pki_relation_and_unmatching_common_name_when_integrat
     assert ops_test.model
     await ops_test.model.integrate(
         relation1=f"{APP_NAME}:vault-pki",
-        relation2=f"{VAULT_PKI_REQUIRER_APPLICATION_NAME}:certificates"
-        )
+        relation2=f"{VAULT_PKI_REQUIRER_APPLICATION_NAME}:certificates",
+    )
     await ops_test.model.wait_for_idle(
-            apps=[APP_NAME],
-            status="active",
-            timeout=1000,
-        )
+        apps=[APP_NAME],
+        status="active",
+        timeout=1000,
+    )
     await ops_test.model.wait_for_idle(
-            apps=[VAULT_PKI_REQUIRER_APPLICATION_NAME],
-            status="active",
-            timeout=1000,
-        )
+        apps=[VAULT_PKI_REQUIRER_APPLICATION_NAME],
+        status="active",
+        timeout=1000,
+    )
 
     root_token, _ = initialize_vault
     leader_unit_address = await get_leader_unit_address(ops_test)
@@ -668,6 +679,7 @@ async def test_given_vault_pki_relation_and_matching_common_name_configured_when
     assert action_output.get("ca-certificate", None) is not None
     assert action_output.get("csr", None) is not None
 
+
 @pytest.mark.abort_on_fail
 async def test_given_vault_integrated_with_s3_when_create_backup_then_action_fails(
     ops_test: OpsTest, deploy_requiring_charms: None
@@ -699,12 +711,13 @@ async def test_given_vault_integrated_with_s3_when_create_backup_then_action_fai
         apps=[APP_NAME],
         status="active",
         timeout=1000,
-         wait_for_exact_units=NUM_VAULT_UNITS,
+        wait_for_exact_units=NUM_VAULT_UNITS,
     )
     vault = ops_test.model.applications[APP_NAME]
     assert isinstance(vault, Application)
     create_backup_action_output = await run_create_backup_action(ops_test)
     assert create_backup_action_output.get("return-code") == 0
+
 
 @pytest.mark.abort_on_fail
 async def test_given_vault_integrated_with_s3_when_list_backups_then_action_fails(
@@ -726,6 +739,7 @@ async def test_given_vault_integrated_with_s3_when_list_backups_then_action_fail
     assert isinstance(vault, Application)
     list_backups_action_output = await run_list_backups_action(ops_test)
     assert list_backups_action_output.get("return-code") == 0
+
 
 @pytest.mark.abort_on_fail
 async def test_given_vault_integrated_with_s3_when_restore_backup_then_action_fails(

--- a/tests/integration/vault.py
+++ b/tests/integration/vault.py
@@ -95,7 +95,7 @@ class Vault:
             servers = response["data"]["config"]["servers"]
             current_num_voters = sum(1 for server in servers if server.get("voter", False))
             current_num_nodes = len(servers)
-            if  current_num_nodes != expected_num_nodes:
+            if current_num_nodes != expected_num_nodes:
                 logger.info(f"Nodes in the raft cluster: {current_num_nodes}/{expected_num_nodes}")
                 continue
             if current_num_voters != expected_num_nodes:

--- a/tests/integration/vault_kv_requirer_operator/src/charm.py
+++ b/tests/integration/vault_kv_requirer_operator/src/charm.py
@@ -43,10 +43,10 @@ class VaultKVRequirerCharm(CharmBase):
             self.model.get_secret(label=NONCE_SECRET_LABEL)
         except SecretNotFoundError:
             self.unit.add_secret(
-            {"nonce": secrets.token_hex(16)},
-            label=NONCE_SECRET_LABEL,
-            description="Nonce for vault-kv relation",
-        )
+                {"nonce": secrets.token_hex(16)},
+                label=NONCE_SECRET_LABEL,
+                description="Nonce for vault-kv relation",
+            )
         self.unit.status = ActiveStatus()
 
     def _on_kv_connected(self, event: VaultKvConnectedEvent):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -47,6 +47,7 @@ VAULT_KV_LIB_PATH = "charms.vault_k8s.v0.vault_kv"
 TLS_CERTIFICATES_PKI_RELATION_NAME = "tls-certificates-pki"
 VAULT_KV_REQUIRER_APPLICATION_NAME = "vault-kv-requirer"
 
+
 class MockNetwork:
     def __init__(self, bind_address: str, ingress_address: str):
         self.bind_address = bind_address
@@ -931,18 +932,18 @@ class TestCharm(unittest.TestCase):
             SecretsBackend.KV_V2, "charm-vault-kv-requirer-suffix"
         )
         self.mock_vault.configure_policy.assert_called_with(
-            policy_name='charm-vault-kv-requirer-suffix-vault-kv-requirer-0',
-            policy_path='src/templates/kv_mount.hcl',
-            mount='charm-vault-kv-requirer-suffix',
+            policy_name="charm-vault-kv-requirer-suffix-vault-kv-requirer-0",
+            policy_path="src/templates/kv_mount.hcl",
+            mount="charm-vault-kv-requirer-suffix",
         )
         self.mock_vault.configure_approle.assert_called_with(
-            role_name='charm-vault-kv-requirer-suffix-vault-kv-requirer-0',
-            policies=['charm-vault-kv-requirer-suffix-vault-kv-requirer-0'],
-            cidrs=['2.2.2.0/24'],
+            role_name="charm-vault-kv-requirer-suffix-vault-kv-requirer-0",
+            policies=["charm-vault-kv-requirer-suffix-vault-kv-requirer-0"],
+            cidrs=["2.2.2.0/24"],
         )
         self.mock_vault.generate_role_secret_id.assert_called_with(
-            name='charm-vault-kv-requirer-suffix-vault-kv-requirer-0',
-            cidrs=['2.2.2.0/24'],
+            name="charm-vault-kv-requirer-suffix-vault-kv-requirer-0",
+            cidrs=["2.2.2.0/24"],
         )
 
     def test_given_s3_relation_not_created_when_create_backup_action_then_action_fails(self):
@@ -952,8 +953,7 @@ class TestCharm(unittest.TestCase):
             self.harness.run_action("create-backup")
 
         self.assertEqual(
-            e.exception.message,
-            "S3 pre-requisites not met. S3 relation not created."
+            e.exception.message, "S3 pre-requisites not met. S3 relation not created."
         )
 
     def test_given_unit_not_leader_when_create_backup_action_then_action_fails(self):
@@ -964,7 +964,7 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(
             e.exception.message,
-            "S3 pre-requisites not met. Only leader unit can perform backup operations."
+            "S3 pre-requisites not met. Only leader unit can perform backup operations.",
         )
 
     @patch(f"{S3_LIB_PATH}.S3Requirer.get_s3_connection_info")
@@ -981,9 +981,8 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(
             e.exception.message,
-            "S3 pre-requisites not met. S3 parameters missing (bucket, access-key, secret-key, endpoint)."  # noqa: E501
+            "S3 pre-requisites not met. S3 parameters missing (bucket, access-key, secret-key, endpoint).",  # noqa: E501
         )
-
 
     @patch("charm.S3")
     @patch(f"{S3_LIB_PATH}.S3Requirer.get_s3_connection_info")
@@ -1005,10 +1004,7 @@ class TestCharm(unittest.TestCase):
         with self.assertRaises(ops.testing.ActionFailed) as e:
             self.harness.run_action("create-backup")
 
-        self.assertEqual(
-            e.exception.message,
-            "Failed to create S3 session."
-        )
+        self.assertEqual(e.exception.message, "Failed to create S3 session.")
 
     @patch(f"{S3_LIB_PATH}.S3Requirer.get_s3_connection_info")
     @patch("charm.S3")
@@ -1017,12 +1013,7 @@ class TestCharm(unittest.TestCase):
         patch_s3,
         patch_get_s3_connection_info,
     ):
-        patch_s3.configure_mock(
-            spec=S3,
-            **{
-                "return_value.create_bucket.return_value": False
-            }
-        )
+        patch_s3.configure_mock(spec=S3, **{"return_value.create_bucket.return_value": False})
         patch_get_s3_connection_info.return_value = self.get_valid_s3_params()
         self.harness.set_leader(is_leader=True)
         self.harness.add_relation(relation_name=S3_RELATION_NAME, remote_app="s3-integrator")
@@ -1030,10 +1021,7 @@ class TestCharm(unittest.TestCase):
         with self.assertRaises(ops.testing.ActionFailed) as e:
             self.harness.run_action("create-backup")
 
-        self.assertEqual(
-            e.exception.message,
-            "Failed to create S3 bucket."
-        )
+        self.assertEqual(e.exception.message, "Failed to create S3 bucket.")
 
     @patch(f"{S3_LIB_PATH}.S3Requirer.get_s3_connection_info")
     @patch("charm.S3")
@@ -1049,12 +1037,7 @@ class TestCharm(unittest.TestCase):
                 "is_initialized.return_value": False,
             },
         )
-        patch_s3.configure_mock(
-            spec=S3,
-            **{
-                "return_value.create_bucket.return_value": True
-            }
-        )
+        patch_s3.configure_mock(spec=S3, **{"return_value.create_bucket.return_value": True})
         self._set_peer_relation()
         self._set_ca_certificate_secret(
             certificate="whatever certificate",
@@ -1067,10 +1050,7 @@ class TestCharm(unittest.TestCase):
         with self.assertRaises(ops.testing.ActionFailed) as e:
             self.harness.run_action("create-backup")
 
-        self.assertEqual(
-            e.exception.message,
-            "Failed to initialize Vault client."
-        )
+        self.assertEqual(e.exception.message, "Failed to initialize Vault client.")
 
     @patch(f"{S3_LIB_PATH}.S3Requirer.get_s3_connection_info")
     @patch("charm.S3")
@@ -1086,12 +1066,7 @@ class TestCharm(unittest.TestCase):
                 "is_initialized.return_value": True,
             },
         )
-        patch_s3.configure_mock(
-            spec=S3,
-            **{
-                "return_value.create_bucket.return_value": True
-            }
-        )
+        patch_s3.configure_mock(spec=S3, **{"return_value.create_bucket.return_value": True})
         self._set_peer_relation()
         self._set_ca_certificate_secret(
             certificate="whatever certificate",
@@ -1104,10 +1079,7 @@ class TestCharm(unittest.TestCase):
         with self.assertRaises(ops.testing.ActionFailed) as e:
             self.harness.run_action("create-backup")
 
-        self.assertEqual(
-            e.exception.message,
-            "Failed to initialize Vault client."
-        )
+        self.assertEqual(e.exception.message, "Failed to initialize Vault client.")
 
     @patch("ops.model.Model.get_binding")
     @patch(f"{S3_LIB_PATH}.S3Requirer.get_s3_connection_info")
@@ -1134,8 +1106,8 @@ class TestCharm(unittest.TestCase):
             spec=S3,
             **{
                 "return_value.create_bucket.return_value": True,
-                "return_value.upload_content.return_value": False
-            }
+                "return_value.upload_content.return_value": False,
+            },
         )
         patch_get_binding.return_value = MockBinding(
             bind_address="1.2.3.4", ingress_address="2.2.2.2"
@@ -1153,10 +1125,7 @@ class TestCharm(unittest.TestCase):
         with self.assertRaises(ops.testing.ActionFailed) as e:
             self.harness.run_action("create-backup")
 
-        self.assertEqual(
-            e.exception.message,
-            "Failed to upload backup to S3 bucket."
-        )
+        self.assertEqual(e.exception.message, "Failed to upload backup to S3 bucket.")
 
     @patch("ops.model.Model.get_binding")
     @patch(f"{S3_LIB_PATH}.S3Requirer.get_s3_connection_info")
@@ -1183,8 +1152,8 @@ class TestCharm(unittest.TestCase):
             spec=S3,
             **{
                 "return_value.create_bucket.return_value": True,
-                "return_value.upload_content.return_value": True
-            }
+                "return_value.upload_content.return_value": True,
+            },
         )
         patch_get_binding.return_value = MockBinding(
             bind_address="1.1.1.1", ingress_address="2.2.2.2"
@@ -1200,13 +1169,9 @@ class TestCharm(unittest.TestCase):
         self.harness.add_relation(relation_name=S3_RELATION_NAME, remote_app="s3-integrator")
 
         action_output = self.harness.run_action("create-backup")
-        self.assertIn(
-            "backup-id",
-            action_output.results
-        )
+        self.assertIn("backup-id", action_output.results)
         backup_id = action_output.results["backup-id"]
         self.assertIn(f"vault-backup-{self.model_name}", backup_id)
-
 
     def test_given_s3_relation_not_created_when_list_backup_action_then_action_fails(self):
         self.harness.set_leader(is_leader=True)
@@ -1215,8 +1180,7 @@ class TestCharm(unittest.TestCase):
             self.harness.run_action("list-backups")
 
         self.assertEqual(
-            e.exception.message,
-            "S3 pre-requisites not met. S3 relation not created."
+            e.exception.message, "S3 pre-requisites not met. S3 relation not created."
         )
 
     def test_given_unit_not_leader_when_list_backups_action_then_action_fails(self):
@@ -1225,7 +1189,7 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(
             e.exception.message,
-            "S3 pre-requisites not met. Only leader unit can perform backup operations."
+            "S3 pre-requisites not met. Only leader unit can perform backup operations.",
         )
 
     @patch(f"{S3_LIB_PATH}.S3Requirer.get_s3_connection_info")
@@ -1242,14 +1206,15 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(
             e.exception.message,
-            "S3 pre-requisites not met. S3 parameters missing (bucket, access-key, secret-key, endpoint)."  # noqa: E501
+            "S3 pre-requisites not met. S3 parameters missing (bucket, access-key, secret-key, endpoint).",  # noqa: E501
         )
 
     @patch("charm.S3")
     @patch(f"{S3_LIB_PATH}.S3Requirer.get_s3_connection_info")
     def test_given_s3_session_not_created_when_list_backups_action_then_action_fails(
         self,
-        patch_get_s3_connection_info, patch_s3,
+        patch_get_s3_connection_info,
+        patch_s3,
     ):
         patch_s3.side_effect = S3Error("Failed to create S3 session.")
         patch_get_s3_connection_info.return_value = self.get_valid_s3_params()
@@ -1259,10 +1224,7 @@ class TestCharm(unittest.TestCase):
         with self.assertRaises(ops.testing.ActionFailed) as e:
             self.harness.run_action("list-backups")
 
-        self.assertEqual(
-            e.exception.message,
-            "Failed to create S3 session."
-        )
+        self.assertEqual(e.exception.message, "Failed to create S3 session.")
 
     @patch(f"{S3_LIB_PATH}.S3Requirer.get_s3_connection_info")
     @patch("charm.S3")
@@ -1270,12 +1232,10 @@ class TestCharm(unittest.TestCase):
         self,
         patch_s3,
         patch_get_s3_connection_info,
-        ):
+    ):
         patch_s3.configure_mock(
             spec=S3,
-            **{
-                "return_value.get_object_key_list.side_effect": S3Error("Failed to list objects.")
-            }
+            **{"return_value.get_object_key_list.side_effect": S3Error("Failed to list objects.")},
         )
         patch_get_s3_connection_info.return_value = self.get_valid_s3_params()
         self.harness.set_leader(is_leader=True)
@@ -1285,21 +1245,18 @@ class TestCharm(unittest.TestCase):
             self.harness.run_action("list-backups")
 
         self.assertEqual(
-            e.exception.message,
-            "Failed to run list-backups action - Failed to list backups."
+            e.exception.message, "Failed to run list-backups action - Failed to list backups."
         )
 
     @patch(f"{S3_LIB_PATH}.S3Requirer.get_s3_connection_info")
     @patch("charm.S3")
     def test_given_s3_list_objects_succeeds_when_list_backups_action_then_action_succeeds(
         self,
-        patch_s3, patch_get_s3_connection_info,
+        patch_s3,
+        patch_get_s3_connection_info,
     ):
         patch_s3.configure_mock(
-            spec=S3,
-            **{
-                "return_value.get_object_key_list.return_value": ["backup1", "backup2"]
-            }
+            spec=S3, **{"return_value.get_object_key_list.return_value": ["backup1", "backup2"]}
         )
         patch_get_s3_connection_info.return_value = self.get_valid_s3_params()
         self.harness.set_leader(is_leader=True)
@@ -1307,15 +1264,9 @@ class TestCharm(unittest.TestCase):
 
         action_output = self.harness.run_action("list-backups")
 
-        self.assertIn(
-            "backup-ids",
-            action_output.results
-        )
+        self.assertIn("backup-ids", action_output.results)
         backup_ids = action_output.results["backup-ids"]
-        self.assertEqual(
-            backup_ids,
-            json.dumps(["backup1", "backup2"])
-        )
+        self.assertEqual(backup_ids, json.dumps(["backup1", "backup2"]))
 
     def test_given_s3_relation_not_created_when_restore_backup_action_then_action_fails(self):
         self.harness.set_leader(is_leader=True)
@@ -1324,8 +1275,7 @@ class TestCharm(unittest.TestCase):
             self.harness.run_action("restore-backup", params={"backup-id": "backup-id"})
 
         self.assertEqual(
-            e.exception.message,
-            "S3 pre-requisites not met. S3 relation not created."
+            e.exception.message, "S3 pre-requisites not met. S3 relation not created."
         )
 
     def test_given_unit_not_leader_when_restore_backup_action_then_action_fails(self):
@@ -1334,7 +1284,7 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(
             e.exception.message,
-            "S3 pre-requisites not met. Only leader unit can perform backup operations."
+            "S3 pre-requisites not met. Only leader unit can perform backup operations.",
         )
 
     @patch(f"{S3_LIB_PATH}.S3Requirer.get_s3_connection_info")
@@ -1351,14 +1301,15 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(
             e.exception.message,
-            "S3 pre-requisites not met. S3 parameters missing (bucket, access-key, secret-key, endpoint)."  # noqa: E501
+            "S3 pre-requisites not met. S3 parameters missing (bucket, access-key, secret-key, endpoint).",  # noqa: E501
         )
 
     @patch("charm.S3")
     @patch(f"{S3_LIB_PATH}.S3Requirer.get_s3_connection_info")
     def test_given_s3_session_not_created_when_restore_backup_action_then_action_fails(
         self,
-        patch_get_s3_connection_info, patch_s3,
+        patch_get_s3_connection_info,
+        patch_s3,
     ):
         patch_s3.side_effect = S3Error("Failed to create S3 session.")
         patch_get_s3_connection_info.return_value = self.get_valid_s3_params()
@@ -1368,10 +1319,7 @@ class TestCharm(unittest.TestCase):
         with self.assertRaises(ops.testing.ActionFailed) as e:
             self.harness.run_action("restore-backup", params={"backup-id": "backup-id"})
 
-        self.assertEqual(
-            e.exception.message,
-            "Failed to create S3 session."
-        )
+        self.assertEqual(e.exception.message, "Failed to create S3 session.")
 
     @patch(f"{S3_LIB_PATH}.S3Requirer.get_s3_connection_info")
     @patch("charm.S3")
@@ -1386,7 +1334,7 @@ class TestCharm(unittest.TestCase):
                 "return_value.get_content.side_effect": S3Error(
                     "Failed to retrieve snapshot from S3 storage."
                 )
-            }
+            },
         )
         patch_get_s3_connection_info.return_value = self.get_valid_s3_params()
         self.harness.set_leader(is_leader=True)
@@ -1395,10 +1343,7 @@ class TestCharm(unittest.TestCase):
         with self.assertRaises(ops.testing.ActionFailed) as e:
             self.harness.run_action("restore-backup", params={"backup-id": "backup-id"})
 
-        self.assertEqual(
-            e.exception.message,
-            "Failed to retrieve snapshot from S3 storage."
-        )
+        self.assertEqual(e.exception.message, "Failed to retrieve snapshot from S3 storage.")
 
     @patch(f"{S3_LIB_PATH}.S3Requirer.get_s3_connection_info")
     @patch("charm.S3")
@@ -1407,12 +1352,7 @@ class TestCharm(unittest.TestCase):
         patch_s3,
         patch_get_s3_connection_info,
     ):
-        patch_s3.configure_mock(
-            spec=S3,
-            **{
-                "return_value.get_content.return_value": None
-            }
-        )
+        patch_s3.configure_mock(spec=S3, **{"return_value.get_content.return_value": None})
         patch_get_s3_connection_info.return_value = self.get_valid_s3_params()
         self.harness.set_leader(is_leader=True)
         self.harness.add_relation(relation_name=S3_RELATION_NAME, remote_app="s3-integrator")
@@ -1420,10 +1360,7 @@ class TestCharm(unittest.TestCase):
         with self.assertRaises(ops.testing.ActionFailed) as e:
             self.harness.run_action("restore-backup", params={"backup-id": "backup-id"})
 
-        self.assertEqual(
-            e.exception.message,
-            "Backup not found in S3 bucket."
-        )
+        self.assertEqual(e.exception.message, "Backup not found in S3 bucket.")
 
     @patch(f"{S3_LIB_PATH}.S3Requirer.get_s3_connection_info")
     @patch("charm.S3")
@@ -1439,12 +1376,7 @@ class TestCharm(unittest.TestCase):
                 "is_initialized.return_value": True,
             },
         )
-        patch_s3.configure_mock(
-            spec=S3,
-            **{
-                "return_value.get_content.return_value": "snapshot"
-            }
-        )
+        patch_s3.configure_mock(spec=S3, **{"return_value.get_content.return_value": "snapshot"})
         patch_get_s3_connection_info.return_value = self.get_valid_s3_params()
         self.harness.set_leader(is_leader=True)
         self.harness.add_relation(relation_name=S3_RELATION_NAME, remote_app="s3-integrator")
@@ -1453,8 +1385,7 @@ class TestCharm(unittest.TestCase):
             self.harness.run_action("restore-backup", params={"backup-id": "backup-id"})
 
         self.assertEqual(
-            e.exception.message,
-            "Failed to restore vault. Vault API is not available."
+            e.exception.message, "Failed to restore vault. Vault API is not available."
         )
 
     @patch("ops.model.Model.get_binding")
@@ -1477,15 +1408,10 @@ class TestCharm(unittest.TestCase):
                 "is_api_available.return_value": True,
                 "is_initialized.return_value": True,
                 "is_sealed.return_value": False,
-                "restore_snapshot.side_effect": VaultClientError()
+                "restore_snapshot.side_effect": VaultClientError(),
             },
         )
-        patch_s3.configure_mock(
-            spec=S3,
-            **{
-                "return_value.get_content.return_value": "snapshot"
-            }
-        )
+        patch_s3.configure_mock(spec=S3, **{"return_value.get_content.return_value": "snapshot"})
         patch_get_s3_connection_info.return_value = self.get_valid_s3_params()
         self.harness.set_leader(is_leader=True)
         self.harness.add_relation(relation_name=S3_RELATION_NAME, remote_app="s3-integrator")
@@ -1493,10 +1419,7 @@ class TestCharm(unittest.TestCase):
         with self.assertRaises(ops.testing.ActionFailed) as e:
             self.harness.run_action("restore-backup", params={"backup-id": "backup-id"})
 
-        self.assertEqual(
-            e.exception.message,
-            "Failed to restore vault."
-        )
+        self.assertEqual(e.exception.message, "Failed to restore vault.")
 
     # Test remove
     @patch("ops.model.Model.get_binding")
@@ -1518,7 +1441,7 @@ class TestCharm(unittest.TestCase):
                 "is_api_available.return_value": True,
                 "is_initialized.return_value": True,
                 "is_sealed.return_value": False,
-                "get_num_raft_peers.return_value": 3
+                "get_num_raft_peers.return_value": 3,
             },
         )
 
@@ -1529,10 +1452,11 @@ class TestCharm(unittest.TestCase):
     def test_given_when_on_remove_then_raft_dbs_are_removed(self):
         self.harness.charm.on.remove.emit()
 
-        self.mock_machine.remove_path.assert_has_calls(calls=[
-            call(path=f"{VAULT_STORAGE_PATH}/vault.db"),
-            call(path=f"{VAULT_STORAGE_PATH}/raft/raft.db"),
-        ]
+        self.mock_machine.remove_path.assert_has_calls(
+            calls=[
+                call(path=f"{VAULT_STORAGE_PATH}/vault.db"),
+                call(path=f"{VAULT_STORAGE_PATH}/raft/raft.db"),
+            ]
         )
 
     @patch("ops.model.Model.get_binding")
@@ -1563,7 +1487,7 @@ class TestCharm(unittest.TestCase):
         )
 
     def test_given_bind_address_not_available_when_generate_vault_scrape_configs_then_config_is_empty(  # noqa: E501
-        self
+        self,
     ):
         actual_config = self.harness.charm.generate_vault_scrape_configs()
         self.assertEqual(

--- a/tox.ini
+++ b/tox.ini
@@ -30,12 +30,14 @@ pass_env =
 description = Apply coding style standards to code
 commands =
     ruff check --fix {[vars]all_path}
+    ruff format {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 commands =
     codespell {tox_root}
     ruff check {[vars]all_path}
+    ruff format --check {[vars]all_path}
 
 [testenv:static]
 description = Run static type checks


### PR DESCRIPTION
Currently, ruff is only configured to check the files for linting errors. This adds ruff formatting to tox checks.

This explains some of the inconsistencies we have had with the formatting, as it depended on how a person's editor was configured.

Review notes:

Only [`tox.ini`](https://github.com/canonical/vault-operator/pull/212/files#diff-ef2cef9f88b4fe09ca3082140e67f5ad34fb65fb6e228f119d3812261ae51449) contains functional changes, the rest are the result of running `tox -e format`.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
