### PR TITLE
fix: Set token ttl

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -258,6 +258,8 @@ class VaultOperatorCharm(CharmBase):
             role_id = vault.configure_approle(
                 role_name="charm",
                 policies=[VAULT_CHARM_POLICY_NAME, VAULT_DEFAULT_POLICY_NAME],
+                token_ttl="1h",
+                token_max_ttl="1h",
             )
             vault_secret_id = vault.generate_role_secret_id(name="charm")
             self._create_approle_secret(role_id, vault_secret_id)
@@ -730,6 +732,8 @@ class VaultOperatorCharm(CharmBase):
             role_name=role_name,
             policies=[policy_name],
             cidrs=[egress_subnet],
+            token_ttl="1h",
+            token_max_ttl="1h",
         )
         role_secret_id = vault.generate_role_secret_id(name=role_name, cidrs=[egress_subnet])
         secret = self._create_or_update_kv_secret(

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -484,7 +484,10 @@ class TestCharm(unittest.TestCase):
             policy_name=VAULT_CHARM_POLICY_NAME, policy_path=VAULT_CHARM_POLICY_PATH
         )
         self.mock_vault.configure_approle.assert_called_once_with(
-            role_name="charm", policies=[VAULT_CHARM_POLICY_NAME, VAULT_DEFAULT_POLICY_NAME]
+            role_name="charm",
+            policies=[VAULT_CHARM_POLICY_NAME, VAULT_DEFAULT_POLICY_NAME],
+            token_ttl="1h",
+            token_max_ttl="1h",
         )
         self.mock_vault.generate_role_secret_id.assert_called_once_with(name="charm")
 
@@ -940,6 +943,8 @@ class TestCharm(unittest.TestCase):
             role_name="charm-vault-kv-requirer-suffix-vault-kv-requirer-0",
             policies=["charm-vault-kv-requirer-suffix-vault-kv-requirer-0"],
             cidrs=["2.2.2.0/24"],
+            token_ttl="1h",
+            token_max_ttl="1h",
         )
         self.mock_vault.generate_role_secret_id.assert_called_with(
             name="charm-vault-kv-requirer-suffix-vault-kv-requirer-0",


### PR DESCRIPTION
Part of the recent changes to `vault_client` removed the default to `token_ttl` and `token_max_ttl`. This means they both need to be set where we were expecting the defaults.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
