### PR TITLE
feat: Auto-unseal

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -33,12 +33,18 @@ storage:
     type: filesystem
     minimum-size: 5M
     location: /var/snap/vault/common/certs
+  config:
+    type: filesystem
+    location: /var/snap/vault/common/config
+    minimum-size: 5M
 
 peers:
   vault-peers:
     interface: vault-peer
 
 provides:
+  vault-autounseal-provides:
+    interface: vault-autounseal
   vault-kv:
     interface: vault-kv
   vault-pki:
@@ -51,6 +57,8 @@ provides:
       Send our CA certificate so clients can trust the CA by means of forming a relation.
 
 requires:
+  vault-autounseal-requires:
+    interface: vault-autounseal
   tls-certificates-access:
     interface: tls-certificates
     limit: 1

--- a/lib/charms/vault_k8s/v0/vault_autounseal.py
+++ b/lib/charms/vault_k8s/v0/vault_autounseal.py
@@ -1,0 +1,503 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Library for the vault-autounseal relation.
+
+This library contains the Requires and Provides classes for handling the
+vault-autounseal interface.
+
+The provider side of the interface is responsible for enabling the vault
+transit engine and creating the necessary keys and policies for an external
+vault to be able to autounseal itself.
+
+The requirer side of the interface is responsible for retrieving the necessary
+details to autounseal the vault instance, and configuring the vault instance to
+use them.
+
+## Getting Started
+
+From a charm directory, fetch the library using `charmcraft`:
+
+```shell
+charmcraft fetch-lib charms.vault_k8s.v0.vault_autounseal
+```
+
+### Provider charm
+
+The provider charm is the charm that provides a Vault instance that can be
+used to autounseal other Vault instances via the Vault transit backend.
+
+Add the following to `metadata.yaml`:
+
+```yaml
+provides:
+  vault-autounseal-provides:
+    interface: vault-autounseal
+```
+
+### Requirer charm
+
+The requirer charm is the charm that wishes to autounseal a Vault instance via
+the Vault transit backend.
+
+Add the following to `metadata.yaml`:
+
+```yaml
+requires:
+  vault-autounseal-requires:
+    interface: vault-autounseal
+    limit: 1
+```
+
+### Integration
+
+You can integrate both charms by running:
+
+```bash
+juju integrate <vault a>:vault-autounseal-provides <vault b>:vault-autounseal-requires
+```
+
+where `vault a` is the Vault app which will provide the autounseal service, and
+`vault b` is the Vault app which will be configured for autounseal via `vault a`.
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+import ops
+from interface_tester import DataBagSchema
+from ops import Relation, RelationDataContent, SecretNotFoundError, model  # type: ignore
+from pydantic import BaseModel, Field, ValidationError
+
+# The unique Charmhub library identifier, never change it
+LIBID = "c33e0a12506444e2b644ac2893ac9394"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 2
+
+
+class LogAdapter(logging.LoggerAdapter):
+    """Adapter for the logger to prepend a prefix to all log lines."""
+
+    prefix = "vault_autounseal"
+
+    def process(self, msg, kwargs):
+        """Decides the format for the prepended text."""
+        return f"[{self.prefix}] {msg}", kwargs
+
+
+logger = LogAdapter(logging.getLogger(__name__), {})
+
+
+class VaultAutounsealProviderSchema(BaseModel):
+    """Provider side of the vault-autounseal relation interface."""
+
+    address: str = Field(description="The address of the Vault server to connect to.")
+    key_name: str = Field(description="The name of the transit key to use for autounseal.")
+    credentials_secret_id: str = Field(
+        description=(
+            "The secret id of the Juju secret which stores the credentials for authenticating with the Vault server."
+        )
+    )
+    ca_certificate: str = Field(
+        description="The CA certificate to use when validating the Vault server's certificate."
+    )
+
+
+class ProviderSchema(DataBagSchema):
+    """The schema for the provider side of this interface."""
+
+    app: VaultAutounsealProviderSchema  # type: ignore
+
+
+class VaultAutounsealDetailsReadyEvent(ops.EventBase):
+    """Event emitted on the requirer when Vault autounseal details are ready in the databag."""
+
+    def __init__(self, handle: ops.Handle, address, key_name, role_id, secret_id, ca_certificate):
+        super().__init__(handle)
+        self.address = address
+        self.key_name = key_name
+        self.role_id = role_id
+        self.secret_id = secret_id
+        self.ca_certificate = ca_certificate
+
+    def snapshot(self) -> Dict[str, Any]:
+        """Return snapshot data that should be persisted."""
+        return dict(
+            super().snapshot(),
+            address=self.address,
+            key_name=self.key_name,
+            role_id=self.role_id,
+            secret_id=self.secret_id,
+            ca_certificate=self.ca_certificate,
+        )
+
+    def restore(self, snapshot: Dict[str, Any]) -> None:
+        """Restore the event from a snapshot."""
+        super().restore(snapshot)
+        self.address = snapshot["address"]
+        self.key_name = snapshot["key_name"]
+        self.role_id = snapshot["role_id"]
+        self.secret_id = snapshot["secret_id"]
+        self.ca_certificate = snapshot["ca_certificate"]
+
+
+class VaultAutounsealProviderRemoved(ops.EventBase):
+    """Event emitted when the vault that provided autounseal capabilities is removed."""
+
+
+class VaultAutounsealRequirerRelationCreated(ops.EventBase):
+    """Event emitted when Vault autounseal should be initialized for a new application."""
+
+    def __init__(self, handle: ops.Handle, relation: model.Relation):
+        super().__init__(handle)
+        self.relation = relation
+
+    def snapshot(self) -> Dict[str, Any]:
+        """Return snapshot data that should be persisted."""
+        return dict(
+            super().snapshot(),
+            relation_id=self.relation.id,
+            relation_name=self.relation.name,
+        )
+
+    def restore(self, snapshot: Dict[str, Any]) -> None:
+        """Restore the event from a snapshot."""
+        super().restore(snapshot)
+        relation = self.framework.model.get_relation(
+            snapshot["relation_name"], snapshot["relation_id"]
+        )
+        if relation is None:
+            raise ValueError(
+                f"Unable to restore {self}: relation {snapshot['relation_name']} (id={snapshot['relation_id']}) not found."
+            )
+        self.relation = relation
+
+
+class VaultAutounsealRequirerRelationBroken(ops.EventBase):
+    """Event emitted on the Provider when a relation to a Requirer is broken."""
+
+    def __init__(self, handle: ops.Handle, relation: model.Relation):
+        super().__init__(handle)
+        self.relation = relation
+
+    def snapshot(self) -> Dict[str, Any]:
+        """Return snapshot data that should be persisted."""
+        return dict(
+            super().snapshot(),
+            relation_id=self.relation.id,
+            relation_name=self.relation.name,
+        )
+
+    def restore(self, snapshot: Dict[str, Any]) -> None:
+        """Restore the event from a snapshot."""
+        super().restore(snapshot)
+        relation = self.framework.model.get_relation(
+            snapshot["relation_name"], snapshot["relation_id"]
+        )
+        if relation is None:
+            raise ValueError(
+                f"Unable to restore {self}: relation {snapshot['relation_name']} (id={snapshot['relation_id']}) not found."
+            )
+        self.relation = relation
+
+
+class VaultAutounsealProvidesEvents(ops.ObjectEvents):
+    """Events raised by the vault-autounseal relation on the provider side."""
+
+    vault_autounseal_requirer_relation_created = ops.EventSource(
+        VaultAutounsealRequirerRelationCreated
+    )
+    vault_autounseal_requirer_relation_broken = ops.EventSource(
+        VaultAutounsealRequirerRelationBroken
+    )
+
+
+class VaultAutounsealRequireEvents(ops.ObjectEvents):
+    """Events raised by the vault-autounseal relation on the requirer side."""
+
+    vault_autounseal_details_ready = ops.EventSource(VaultAutounsealDetailsReadyEvent)
+    vault_autounseal_provider_relation_broken = ops.EventSource(VaultAutounsealProviderRemoved)
+
+
+@dataclass
+class AutounsealDetails:
+    """The details required to autounseal a vault instance."""
+
+    address: str
+    key_name: str
+    role_id: str
+    secret_id: str
+    ca_certificate: str
+
+
+@dataclass
+class ApproleDetails:
+    """The details required to authenticate with Vault using the approle auth method."""
+
+    role_id: str
+    secret_id: str
+
+
+class VaultAutounsealProvides(ops.Object):
+    """Manages the vault-autounseal relation from the provider side."""
+
+    on: VaultAutounsealProvidesEvents = VaultAutounsealProvidesEvents()  # type: ignore
+
+    def __init__(self, charm: ops.CharmBase, relation_name: str):
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.relation_name = relation_name
+
+        self.framework.observe(
+            self.charm.on[relation_name].relation_created, self._on_relation_created
+        )
+        self.framework.observe(
+            self.charm.on[relation_name].relation_broken, self._on_relation_broken
+        )
+
+    def _on_relation_created(self, event: ops.RelationCreatedEvent) -> None:
+        self.on.vault_autounseal_requirer_relation_created.emit(relation=event.relation)
+
+    def _on_relation_broken(self, event: ops.RelationBrokenEvent) -> None:
+        self.on.vault_autounseal_requirer_relation_broken.emit(relation=event.relation)
+
+    def _create_autounseal_credentials_secret(
+        self, relation: ops.Relation, role_id: str, secret_id: str
+    ) -> str:
+        """Create a Juju secret with the autounseal credentials.
+
+        Args:
+            relation: The relation to grant access to the secret.
+            role_id: The AppRole Role ID to store in the secret.
+            secret_id: The AppRole Secret ID to store in the secret.
+
+        Returns:
+            The secret id of the created secret.
+        """
+        secret = self.charm.app.add_secret(
+            {
+                "role-id": role_id,
+                "secret-id": secret_id,
+            },
+        )
+        secret.grant(relation)
+        if secret.id is None:
+            raise ValueError("Secret id is None")
+        return secret.id
+
+    def set_autounseal_data(
+        self,
+        relation: ops.Relation,
+        vault_address: str,
+        key_name: str,
+        approle_role_id: str,
+        approle_secret_id: str,
+        ca_certificate: str,
+    ) -> None:
+        """Set the autounseal data in the relation databag.
+
+        Args:
+            relation: The Juju relation to set the autounseal data in.
+            vault_address: The address of the Vault server which will be used for autounseal
+            key_name: The name of the transit key to use for autounseal.
+            approle_role_id: The AppRole Role ID to use when authenticating with the external Vault server.
+            approle_secret_id: The AppRole Secret ID to use when authenticating with the external Vault server.
+            ca_certificate: The CA certificate to use when validating the external Vault server's certificate.
+        """
+        if not self.charm.unit.is_leader():
+            logger.warning(
+                "Attempting to set the auto-unseal data without being the leader. Ignoring the request."
+            )
+            return
+        if relation is None:
+            logger.warning("No relation found")
+            return
+        if not relation.active:
+            logger.warning("Relation is not active")
+            return
+        credentials_secret_id = self._create_autounseal_credentials_secret(
+            relation, approle_role_id, approle_secret_id
+        )
+        relation.data[self.charm.app].update(
+            {
+                "address": vault_address,
+                "key_name": key_name,
+                "credentials_secret_id": credentials_secret_id,
+                "ca_certificate": ca_certificate,
+            }
+        )
+
+    def get_outstanding_requests(self, relation_id: Optional[int] = None) -> List[Relation]:
+        """Get the outstanding requests for the relation.
+
+        This will retrieve any vault-autounseal relations that have not yet had
+        credentials issued for them.
+        """
+        outstanding_requests: List[Relation] = []
+        requirer_requests = self.get_active_relations(relation_id=relation_id)
+        for relation in requirer_requests:
+            if not self._credentials_issued_for_request(relation_id=relation.id):
+                outstanding_requests.append(relation)
+        return outstanding_requests
+
+    def get_active_relations(self, relation_id: Optional[int] = None) -> List[Relation]:
+        """Get all active relations on the relation name this class was initialized with.
+
+        Args:
+            relation_id: The relation ID to filter by. If None, all active relations are returned.
+
+        Returns:
+            A list of active relations.
+        """
+        relations = (
+            [
+                relation
+                for relation in self.model.relations[self.relation_name]
+                if relation.id == relation_id
+            ]
+            if relation_id is not None
+            else self.model.relations.get(self.relation_name, [])
+        )
+        return [relation for relation in relations if relation.active]
+
+    def _credentials_issued_for_request(self, relation_id: Optional[int]) -> bool:
+        relation = self.model.get_relation(self.relation_name, relation_id)
+        if not relation:
+            return False
+        credentials = self._get_credentials(relation)
+        return credentials is not None
+
+    def _get_credentials(self, relation: ops.Relation) -> Optional[ApproleDetails]:
+        """Retrieve the credentials from the Juju secret.
+
+        Args:
+            relation: The relation to get the credentials for.
+
+        Returns:
+            An ApproleDetails object if the credentials are found, None otherwise.
+        """
+        if not relation.active:
+            logger.warning("Relation is not active")
+            return None
+        if relation.app is None:
+            logger.warning("No remote application yet")
+            return None
+        credentials_secret_id = relation.data[relation.app].get("credentials_secret_id")
+        if credentials_secret_id is None:
+            return None
+        secret = self.model.get_secret(id=credentials_secret_id)
+        return _get_credentials_from_secret(secret)
+
+
+def _is_provider_data_valid(data: RelationDataContent) -> bool:
+    """Use the pydantic schema to validate the data."""
+    try:
+        ProviderSchema(app=VaultAutounsealProviderSchema(**data))
+        return True
+    except ValidationError as e:
+        logger.warning("Invalid data: %s", e)
+        return False
+
+
+class VaultAutounsealRequires(ops.Object):
+    """Manages the vault-autounseal relation from the requirer side."""
+
+    on: VaultAutounsealRequireEvents = VaultAutounsealRequireEvents()  # type: ignore
+
+    def __init__(self, charm: ops.CharmBase, relation_name: str):
+        super().__init__(charm, relation_name)
+        self.relation_name = relation_name
+
+        self.framework.observe(charm.on[relation_name].relation_changed, self._on_relation_changed)
+        self.framework.observe(charm.on[relation_name].relation_broken, self._on_relation_broken)
+
+    def _on_relation_changed(self, event: ops.RelationChangedEvent) -> None:
+        data = event.relation.data[event.app]
+        if _is_provider_data_valid(data):
+            details = self.get_details()
+            if not details:
+                logger.warning("Missing details, but somehow we passed validation")
+                return
+            self.on.vault_autounseal_details_ready.emit(
+                details.address,
+                details.key_name,
+                details.role_id,
+                details.secret_id,
+                details.ca_certificate,
+            )
+
+    def _on_relation_broken(self, event: ops.RelationBrokenEvent) -> None:
+        self.on.vault_autounseal_provider_relation_broken.emit()
+
+    def get_details(self) -> Optional[AutounsealDetails]:
+        """Return the vault address, role id, secret id and ca certificate from the relation databag.
+
+        Returns:
+            An AutounsealDetails object if the data is valid, None otherwise.
+        """
+        relation = self.framework.model.get_relation(self.relation_name)
+        if not relation:
+            return None
+        if not relation.active:
+            return None
+        if relation.app is None:
+            logger.warning("No remote application yet")
+            return None
+        data = relation.data[relation.app]
+        address = data.get("address")
+        key_name = data.get("key_name")
+        ca_certificate = data.get("ca_certificate")
+        credentials = self._get_credentials(relation)
+        if not (address and key_name and ca_certificate and credentials):
+            return None
+        return AutounsealDetails(
+            address,
+            key_name,
+            credentials.role_id,
+            credentials.secret_id,
+            ca_certificate,
+        )
+
+    def _get_credentials(self, relation: ops.Relation) -> Optional[ApproleDetails]:
+        """Return the token from the Juju secret.
+
+        Returns:
+            A tuple containing the role id and secret id
+        """
+        if not relation.active:
+            logger.warning("Relation is not active")
+            return None
+        if relation.app is None:
+            logger.warning("No remote application yet")
+            return None
+        credentials_secret_id = relation.data[relation.app].get("credentials_secret_id")
+        if not credentials_secret_id:
+            return None
+        secret = self.model.get_secret(id=credentials_secret_id)
+        return _get_credentials_from_secret(secret)
+
+
+def _get_credentials_from_secret(secret: ops.Secret) -> Optional[ApproleDetails]:
+    """Retrieve the Approle credentials from the Juju secret.
+
+    Args:
+        secret: The secret to get the credentials for.
+
+    Returns:
+        An ApproleDetails object if the credentials are found, None otherwise.
+    """
+    try:
+        secret_content = secret.get_content(refresh=True)
+    except SecretNotFoundError:
+        logger.warning("Secret not found")
+        return None
+    role_id = secret_content.get("role-id")
+    secret_id = secret_content.get("secret-id")
+    return ApproleDetails(role_id, secret_id) if role_id and secret_id else None

--- a/lib/charms/vault_k8s/v0/vault_client.py
+++ b/lib/charms/vault_k8s/v0/vault_client.py
@@ -155,7 +155,11 @@ class Vault:
 
     def is_sealed(self) -> bool:
         """Return whether Vault is sealed."""
-        return self._client.sys.is_sealed()
+        try:
+            return self._client.sys.is_sealed()
+        except VaultError as e:
+            logging.error("Error while checking Vault seal status: %s", e)
+            raise VaultClientError(e) from e
 
     def needs_migration(self) -> bool:
         """Return true if the vault needs to be migrated, false otherwise."""

--- a/lib/charms/vault_k8s/v0/vault_client.py
+++ b/lib/charms/vault_k8s/v0/vault_client.py
@@ -26,7 +26,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 14
 
 
 RAFT_STATE_ENDPOINT = "v1/sys/storage/raft/autopilot/state"
@@ -158,6 +158,15 @@ class Vault:
         try:
             return self._client.sys.is_sealed()
         except VaultError as e:
+            # This seems to happen if the seal status is checked immediately
+            # after initializing the vault when autounseal is enabled.
+            # There is a short period of time where the vault is initialized,
+            # but hasn't finished setting up the autounseal configuration yet,
+            # and the server will return an internal server error during this
+            # period.
+            #
+            # hvac.exceptions.InternalServerError:
+            # core: barrier reports initialized but no seal configuration found
             logging.error("Error while checking Vault seal status: %s", e)
             raise VaultClientError(e) from e
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -132,7 +132,7 @@ def _render_vault_config_file(
     return content
 
 
-def _seal_type_has_changed(content_a: str, content_b: str) -> bool:
+def _seal_types_are_different(content_a: str, content_b: str) -> bool:
     """Check if the seal type has changed between two versions of the Vault configuration file.
 
     Currently only checks if the transit stanza is present or not, since this
@@ -1409,7 +1409,7 @@ class VaultOperatorCharm(CharmBase):
             # If the seal type has changed, we need to restart Vault to apply
             # the changes. SIGHUP is currently only supported as a beta feature
             # for the enterprise version in Vault 1.16+
-            if _seal_type_has_changed(existing_content, content):
+            if _seal_types_are_different(existing_content, content):
                 if self._vault_service_is_running():
                     self.machine.restart(VAULT_SNAP_NAME)
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -9,6 +9,7 @@ import datetime
 import json
 import logging
 from contextlib import contextmanager
+from dataclasses import dataclass
 from typing import Dict, List, Optional
 
 import hcl
@@ -20,6 +21,12 @@ from charms.tls_certificates_interface.v3.tls_certificates import (
     CertificateCreationRequestEvent,
     TLSCertificatesProvidesV3,
     TLSCertificatesRequiresV3,
+)
+from charms.vault_k8s.v0.vault_autounseal import (
+    AutounsealDetails,
+    VaultAutounsealProvides,
+    VaultAutounsealRequirerRelationBroken,
+    VaultAutounsealRequires,
 )
 from charms.vault_k8s.v0.vault_client import (
     AppRole,
@@ -33,6 +40,7 @@ from charms.vault_k8s.v0.vault_kv import NewVaultKvClientAttachedEvent, VaultKvP
 from charms.vault_k8s.v0.vault_s3 import S3, S3Error
 from charms.vault_k8s.v0.vault_tls import (
     File,
+    VaultCertsError,
     VaultTLSManager,
 )
 from cryptography import x509
@@ -45,6 +53,11 @@ from ops.model import ActiveStatus, MaintenanceStatus, ModelError, Relation, Wai
 
 logger = logging.getLogger(__name__)
 
+AUTOUNSEAL_MOUNT_PATH = "charm-autounseal"
+AUTOUNSEAL_POLICY_PATH = "src/templates/autounseal_policy.hcl"
+AUTOUNSEAL_PROVIDES_RELATION_NAME = "vault-autounseal-provides"
+AUTOUNSEAL_REQUIRES_RELATION_NAME = "vault-autounseal-requires"
+AUTOUNSEAL_TOKEN_SECRET_LABEL = "vault-autounseal-token"
 BACKUP_KEY_PREFIX = "vault-backup"
 CONFIG_TEMPLATE_DIR_PATH = "src/templates/"
 CONFIG_TEMPLATE_NAME = "vault.hcl.j2"
@@ -74,7 +87,17 @@ VAULT_SNAP_REVISION = "2226"
 VAULT_STORAGE_PATH = "/var/snap/vault/common/raft"
 
 
-def render_vault_config_file(
+@dataclass
+class AutounsealConfigurationDetails:
+    """Credentials required for configuring auto-unseal on Vault."""
+
+    address: str
+    key_name: str
+    token: str
+    ca_cert_path: str
+
+
+def _render_vault_config_file(
     default_lease_ttl: str,
     max_lease_ttl: str,
     cluster_address: str,
@@ -85,8 +108,8 @@ def render_vault_config_file(
     raft_storage_path: str,
     node_id: str,
     retry_joins: List[Dict[str, str]],
+    autounseal_details: Optional[AutounsealConfigurationDetails] = None,
 ) -> str:
-    """Render the Vault config file."""
     jinja2_environment = Environment(loader=FileSystemLoader(CONFIG_TEMPLATE_DIR_PATH))
     template = jinja2_environment.get_template(CONFIG_TEMPLATE_NAME)
     content = template.render(
@@ -100,8 +123,31 @@ def render_vault_config_file(
         raft_storage_path=raft_storage_path,
         node_id=node_id,
         retry_joins=retry_joins,
+        autounseal_address=autounseal_details.address if autounseal_details else None,
+        autounseal_key_name=autounseal_details.key_name if autounseal_details else None,
+        autounseal_mount_path=AUTOUNSEAL_MOUNT_PATH if autounseal_details else None,
+        autounseal_token=autounseal_details.token if autounseal_details else None,
+        autounseal_tls_ca_cert=autounseal_details.ca_cert_path if autounseal_details else None,
     )
     return content
+
+
+def _seal_type_has_changed(content_a: str, content_b: str) -> bool:
+    """Check if the seal type has changed between two versions of the Vault configuration file.
+
+    Currently only checks if the transit stanza is present or not, since this
+    is all we support. This function will need to be extended to support
+    alternate cases if and when we support them.
+    """
+    config_a = hcl.loads(content_a)
+    config_b = hcl.loads(content_b)
+    return _contains_transit_stanza(config_a) != _contains_transit_stanza(config_b)
+
+
+def _contains_transit_stanza(config: dict) -> bool:
+    if "seal" in config and "transit" in config["seal"]:
+        return True
+    return False
 
 
 def config_file_content_matches(existing_content: str, new_content: str) -> bool:
@@ -179,6 +225,12 @@ class VaultOperatorCharm(CharmBase):
         self.framework.observe(self.on.remove, self._on_remove)
         self.framework.observe(self.on[PEER_RELATION_NAME].relation_created, self._configure)
         self.framework.observe(self.on[PEER_RELATION_NAME].relation_changed, self._configure)
+        self.vault_autounseal_provides = VaultAutounsealProvides(
+            self, AUTOUNSEAL_PROVIDES_RELATION_NAME
+        )
+        self.vault_autounseal_requires = VaultAutounsealRequires(
+            self, AUTOUNSEAL_REQUIRES_RELATION_NAME
+        )
         self.framework.observe(self.on.authorize_charm_action, self._on_authorize_charm_action)
         self.framework.observe(
             self.vault_kv.on.new_vault_kv_client_attached, self._on_new_vault_kv_client_attached
@@ -198,6 +250,136 @@ class VaultOperatorCharm(CharmBase):
         self.framework.observe(self.on.create_backup_action, self._on_create_backup_action)
         self.framework.observe(self.on.list_backups_action, self._on_list_backups_action)
         self.framework.observe(self.on.restore_backup_action, self._on_restore_backup_action)
+        self.framework.observe(
+            self.vault_autounseal_requires.on.vault_autounseal_details_ready,
+            self._configure,
+        )
+        self.framework.observe(
+            self.vault_autounseal_provides.on.vault_autounseal_requirer_relation_created,
+            self._configure,
+        )
+        self.framework.observe(
+            self.vault_autounseal_provides.on.vault_autounseal_requirer_relation_broken,
+            self._on_vault_autounseal_requirer_relation_broken,
+        )
+        self.framework.observe(
+            self.vault_autounseal_requires.on.vault_autounseal_provider_relation_broken,
+            self._configure,
+        )
+
+    def _on_vault_autounseal_requirer_relation_broken(
+        self, event: VaultAutounsealRequirerRelationBroken
+    ):
+        if not self.unit.is_leader():
+            return
+
+        vault = self._get_active_vault_client()
+        if vault is None:
+            logger.warning("Vault is not active, cannot disable vault autounseal")
+            return
+        vault.destroy_autounseal_credentials(event.relation.id, AUTOUNSEAL_MOUNT_PATH)
+
+    def _get_active_vault_client(self) -> Optional[Vault]:
+        """Return an initialized vault client.
+
+        Returns:
+            Vault: An active Vault client configured with the cluster address
+                   and CA certificate, and authorized with the AppRole
+                   credentials set upon initial authorization of the charm, or
+                   `None` if the client could not be successfully created or
+                   has not been authorized.
+        """
+        if not self._api_address:
+            return None
+        try:
+            vault = Vault(
+                url=self._api_address,
+                ca_cert_path=self.tls.get_tls_file_path_in_charm(File.CA),
+            )
+        except VaultCertsError as e:
+            logger.warning("Failed to get Vault client: %s", e)
+            return None
+        if not vault.is_api_available():
+            return None
+        approle = self._get_vault_approle()
+        if not approle:
+            return None
+        if not vault.authenticate(approle):
+            return None
+        if not vault.is_active_or_standby():
+            return None
+        return vault
+
+    def _generate_and_set_autounseal_credentials(self, relation: Relation) -> None:
+        """If leader, generate new credentials for the auto-unseal requirer.
+
+        These credentials are generated and then set in the relation databag so
+        that the requiring app can retrieve them, and use them to create tokens
+        that have the appropriate permissions to use the autounseal key.
+        """
+        if not self.unit.is_leader():
+            return
+        vault = self._get_active_vault_client()
+        if vault is None:
+            logger.warning("Vault is not active, cannot generate autounseal credentials")
+            return
+
+        vault.enable_secrets_engine(SecretsBackend.TRANSIT, AUTOUNSEAL_MOUNT_PATH)
+
+        key_name, approle_id, secret_id = vault.create_autounseal_credentials(
+            relation.id,
+            AUTOUNSEAL_MOUNT_PATH,
+            AUTOUNSEAL_POLICY_PATH,
+        )
+
+        self._set_autounseal_relation_data(relation, key_name, approle_id, secret_id)
+
+    def _sync_vault_autounseal(self) -> None:
+        """Go through all the vault-autounseal relations and send necessary credentials.
+
+        This looks for any outstanding requests for auto-unseal that may have
+        been missed. If there are any, it generates the credentials and sets
+        them in the relation databag.
+        """
+        if not self.unit.is_leader():
+            logger.debug("Only leader unit can handle a vault-autounseal request")
+            return
+        outstanding_requests = self.vault_autounseal_provides.get_outstanding_requests()
+        for relation in outstanding_requests:
+            self._generate_and_set_autounseal_credentials(relation)
+
+    def _set_autounseal_relation_data(
+        self, relation: Relation, key_name: str, approle_id: str, approle_secret_id: str
+    ) -> None:
+        """Set the required autounseal data in the relation databag.
+
+        Args:
+            relation: Relation for which the auto-unseal data is being set
+            key_name: The vault transit key name used for auto-unseal
+            approle_id: The AppRole ID which has permission to use this key
+            approle_secret_id: The AppRole secret ID
+        """
+        vault_address = self._get_relation_api_address(relation)
+        if not vault_address:
+            logger.warning("Vault address not available, ignoring request to set autounseal data")
+            return
+        ca_cert = (
+            self.tls.pull_tls_file_from_workload(File.CA)
+            if self.tls.ca_certificate_is_saved()
+            else None
+        )
+        if not ca_cert:
+            logger.warning("CA certificate not available, ignoring request to set autounseal data")
+            return
+
+        self.vault_autounseal_provides.set_autounseal_data(
+            relation,
+            vault_address,
+            key_name,
+            approle_id,
+            approle_secret_id,
+            ca_cert,
+        )
 
     def generate_vault_scrape_configs(self) -> Optional[List[Dict]]:
         """Generate the scrape configs for the COS agent.
@@ -325,10 +507,23 @@ class VaultOperatorCharm(CharmBase):
             event.add_status(WaitingStatus("Vault API is not yet available"))
             return
         if not vault.is_initialized():
-            event.add_status(BlockedStatus("Please initialize Vault"))
+            if vault.is_seal_type_transit():
+                event.add_status(BlockedStatus("Please initialize Vault"))
+                return
+
+            event.add_status(
+                BlockedStatus("Please initialize Vault or integrate with an auto-unseal provider")
+            )
             return
-        if vault.is_sealed():
-            event.add_status(BlockedStatus("Please unseal Vault"))
+        try:
+            if vault.is_sealed():
+                if vault.needs_migration():
+                    event.add_status(BlockedStatus("Please migrate Vault"))
+                    return
+                event.add_status(BlockedStatus("Please unseal Vault"))
+                return
+        except VaultClientError:
+            event.add_status(MaintenanceStatus("Seal check failed, waiting for Vault to recover"))
             return
         if not self._get_vault_approle():
             event.add_status(
@@ -362,6 +557,7 @@ class VaultOperatorCharm(CharmBase):
         self._set_peer_relation_node_api_address()
         self._configure_pki_secrets_engine()
         self._add_intermediate_ca_certificate_to_pki_secrets_engine()
+        self._sync_vault_autounseal()
         self._sync_vault_kv()
         self._sync_vault_pki()
         self.tls.send_ca_cert()
@@ -595,7 +791,8 @@ class VaultOperatorCharm(CharmBase):
 
     def _vault_service_is_running(self) -> bool:
         """Check if the Vault service is running."""
-        return self.machine.get_service(process=VAULT_SNAP_NAME) is not None
+        service = self.machine.get_service(process=VAULT_SNAP_NAME)
+        return False if not service else service.is_running()
 
     def _delete_vault_data(self) -> None:
         """Delete Vault's data."""
@@ -1081,6 +1278,69 @@ class VaultOperatorCharm(CharmBase):
         vault_snap.start(services=["vaultd"])
         logger.debug("Vault service started")
 
+    def _get_autounseal_configuration(self) -> Optional[AutounsealConfigurationDetails]:
+        """Retrieve the autounseal configuration details, if available.
+
+        Returns the autounseal configuration details if all the required
+        information is available, otherwise `None`.
+        """
+        autounseal_details = self.vault_autounseal_requires.get_details()
+        if not autounseal_details:
+            return None
+
+        self.tls.push_autounseal_ca_cert(autounseal_details.ca_certificate)
+
+        return AutounsealConfigurationDetails(
+            autounseal_details.address,
+            autounseal_details.key_name,
+            self._get_autounseal_vault_token(autounseal_details),
+            self.tls.get_tls_file_path_in_workload(File.AUTOUNSEAL_CA),
+        )
+
+    def _get_autounseal_vault_token(self, autounseal_details: AutounsealDetails) -> str:
+        """Retrieve the auto-unseal Vault token, or generate a new one if required.
+
+        Retrieves the last used token from Juju secrets, and validates that it
+        is still valid. If the token is not valid, a new token is generated and
+        stored in the Juju secret. A valid token is returned.
+
+        Args:
+            autounseal_details: The autounseal configuration details.
+
+        Returns:
+            A periodic Vault token that can be used for auto-unseal.
+        """
+        vault = Vault(
+            url=autounseal_details.address,
+            ca_cert_path=self.tls.get_tls_file_path_in_charm(File.AUTOUNSEAL_CA),
+        )
+        existing_token = self._get_juju_secret_field(AUTOUNSEAL_TOKEN_SECRET_LABEL, "token")
+        # If we don't already have a token, or if the existing token is invalid,
+        # authenticate with the AppRole details to generate a new token.
+        if not existing_token or not vault.authenticate(Token(existing_token)):
+            vault.authenticate(AppRole(autounseal_details.role_id, autounseal_details.secret_id))
+            self._set_juju_secret(AUTOUNSEAL_TOKEN_SECRET_LABEL, {"token": vault.token})
+        return vault.token
+
+    def _get_juju_secret_field(self, label: str, field: str) -> Optional[str]:
+        """Retrieve the latest revision of the secret content from Juju.
+
+        Args:
+            label: The label of the secret.
+            field: The field to retrieve from the secret.
+
+        Returns:
+            The value of the field is returned, or `None` if the field does not
+            exist.
+            If the secret does not exist, `None` is returned.
+        """
+        try:
+            juju_secret = self.model.get_secret(label=label)
+        except SecretNotFoundError:
+            return None
+        content = juju_secret.get_content(refresh=True)
+        return content.get(field)
+
     def _generate_vault_config_file(self) -> None:
         """Create the Vault config file and push it to the Machine."""
         assert self._cluster_address
@@ -1092,7 +1352,7 @@ class VaultOperatorCharm(CharmBase):
             }
             for node_api_address in self._other_peer_node_api_addresses()
         ]
-        content = render_vault_config_file(
+        content = _render_vault_config_file(
             default_lease_ttl=self._get_default_lease_ttl(),
             max_lease_ttl=self._get_max_lease_ttl(),
             cluster_address=self._cluster_address,
@@ -1103,6 +1363,7 @@ class VaultOperatorCharm(CharmBase):
             raft_storage_path=VAULT_STORAGE_PATH,
             node_id=self._node_id,
             retry_joins=retry_joins,
+            autounseal_details=self._get_autounseal_configuration(),
         )
         existing_content = ""
         vault_config_file_path = f"{VAULT_CONFIG_PATH}/{VAULT_CONFIG_FILE_NAME}"
@@ -1115,6 +1376,12 @@ class VaultOperatorCharm(CharmBase):
                 path=vault_config_file_path,
                 source=content,
             )
+            # If the seal type has changed, we need to restart Vault to apply
+            # the changes. SIGHUP is currently only supported as a beta feature
+            # for the enterprise version in Vault 1.16+
+            if _seal_type_has_changed(existing_content, content):
+                if self._vault_service_is_running():
+                    self.machine.restart(VAULT_SNAP_NAME)
 
     def _is_peer_relation_created(self) -> bool:
         """Check if the peer relation is created."""

--- a/src/templates/autounseal_policy.hcl
+++ b/src/templates/autounseal_policy.hcl
@@ -1,0 +1,7 @@
+path "{mount}/encrypt/{key_name}" {{
+    capabilities = ["update"]
+}}
+
+path "{mount}/decrypt/{key_name}" {{
+    capabilities = ["update"]
+}}

--- a/src/templates/charm_policy.hcl
+++ b/src/templates/charm_policy.hcl
@@ -61,3 +61,8 @@ path "sys/storage/raft/snapshot" {
 path "sys/storage/raft/snapshot-force" {
   capabilities = ["update"]
 }
+
+# Vault Transit permissions
+path "charm-transit/*" {
+  capabilities = ["create", "read", "update", "delete", "list"]
+}

--- a/src/templates/vault.hcl.j2
+++ b/src/templates/vault.hcl.j2
@@ -26,3 +26,13 @@ telemetry {
   disable_hostname = true
   prometheus_retention_time = "12h"
 }
+{% if autounseal_address %}
+seal "transit" {
+  address         = "{{ autounseal_address }}"
+  disable_renewal = "false"
+  key_name        = "{{ autounseal_key_name }}"
+  mount_path      = "{{ autounseal_mount_path }}"
+  token           = "{{ autounseal_token }}"
+  tls_ca_cert     = "{{ autounseal_tls_ca_cert }}"
+}
+{% endif %}

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -55,7 +55,7 @@ async def wait_for_vault_status_message(
 
     This function is necessary because ops_test doesn't provide the facilities
     to discriminate depending on the status message of the units, just the
-    statuses themselves.
+    application statuses.
 
     Args:
         ops_test: Ops test Framework.

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -2,7 +2,22 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import time
+from pathlib import Path
+from typing import List
+
+import yaml
 from juju.unit import Unit
+from pytest_operator.plugin import OpsTest
+
+# Vault status codes, see
+# https://developer.hashicorp.com/vault/api-docs/system/health for more details
+METADATA = yaml.safe_load(Path("./charmcraft.yaml").read_text())
+APP_NAME = METADATA["name"]
+VAULT_STATUS_ACTIVE = 200
+VAULT_STATUS_UNSEALED_AND_STANDBY = 429
+VAULT_STATUS_NOT_INITIALIZED = 501
+VAULT_STATUS_SEALED = 503
 
 
 async def get_leader_unit(model, application_name: str) -> Unit:
@@ -11,3 +26,58 @@ async def get_leader_unit(model, application_name: str) -> Unit:
         if unit.application == application_name and await unit.is_leader_from_status():
             return unit
     raise RuntimeError(f"Leader unit for `{application_name}` not found.")
+
+
+async def get_unit_status_messages(
+    ops_test: OpsTest, app_name: str = APP_NAME
+) -> List[tuple[str, str]]:
+    """Get the status messages from all the units of the given application."""
+    return_code, stdout, stderr = await ops_test.juju("status", "--format", "yaml", app_name)
+    if return_code:
+        raise RuntimeError(stderr)
+    output = yaml.safe_load(stdout)
+    unit_statuses = output["applications"][app_name]["units"]
+    return [
+        (unit_name, unit_status["workload-status"]["message"])
+        for (unit_name, unit_status) in unit_statuses.items()
+    ]
+
+
+async def wait_for_vault_status_message(
+    ops_test: OpsTest,
+    count: int,
+    expected_message: str,
+    timeout: int = 100,
+    cadence: int = 2,
+    app_name: str = APP_NAME,
+) -> None:
+    """Wait for the correct vault status messages to appear.
+
+    This function is necessary because ops_test doesn't provide the facilities
+    to discriminate depending on the status message of the units, just the
+    statuses themselves.
+
+    Args:
+        ops_test: Ops test Framework.
+        count: How many units that are expected to be emitting the expected message
+        expected_message: The message that vault units should be setting as a status message
+        timeout: Wait time in seconds to get proxied endpoints.
+        cadence: How long to wait before running the command again
+        app_name: Application name of the Vault, defaults to "vault-k8s"
+
+    Raises:
+        TimeoutError: If the expected amount of statuses weren't found in the given timeout.
+    """
+    seen = 0
+    while timeout > 0:
+        unit_statuses = await get_unit_status_messages(ops_test, app_name=app_name)
+        seen = 0
+        for unit_name, unit_status_message in unit_statuses:
+            if unit_status_message == expected_message:
+                seen += 1
+
+        if seen == count:
+            return
+        time.sleep(cadence)
+        timeout -= cadence
+    raise TimeoutError(f"Vault didn't show the expected status: `{expected_message}`")

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -852,7 +852,7 @@ async def test_given_vault_is_deployed_when_integrate_another_vault_then_autouns
 
 @pytest.mark.abort_on_fail
 @pytest.mark.autounseal
-async def test_given_vault_b_is_deployed_and_unsealed_when_add_unit_then_status_is_active(
+async def test_given_vault_b_is_deployed_and_autounsealed_when_add_unit_then_status_is_active(
     ops_test: OpsTest, deployed_vault_initialized_leader: None
 ):
     assert ops_test.model

--- a/tests/integration/vault.py
+++ b/tests/integration/vault.py
@@ -31,9 +31,20 @@ class Vault:
 
     def initialize(self) -> Tuple[str, str]:
         """Initialize the vault unit and return the root token and unseal key."""
-        initialize_response = self.client.sys.initialize(secret_shares=1, secret_threshold=1)
-        root_token, unseal_key = initialize_response["root_token"], initialize_response["keys"][0]
-        return root_token, unseal_key
+        seal_type = self.client.seal_status["type"]  # type: ignore -- bad type hints in stubs
+        if seal_type == "shamir":
+            initialize_response = self.client.sys.initialize(secret_shares=1, secret_threshold=1)
+            root_token, unseal_key = (
+                initialize_response["root_token"],
+                initialize_response["keys"][0],
+            )
+            return root_token, unseal_key
+        initialize_response = self.client.sys.initialize(recovery_shares=1, recovery_threshold=1)
+        root_token, recovery_key = (
+            initialize_response["root_token"],
+            initialize_response["recovery_keys"][0],
+        )
+        return root_token, recovery_key
 
     def is_initialized(self) -> bool:
         """Check if the vault unit is initialized."""

--- a/tests/integration/vault.py
+++ b/tests/integration/vault.py
@@ -32,11 +32,19 @@ class Vault:
     def initialize(self) -> Tuple[str, str]:
         """Initialize the vault unit and return the root token and unseal key."""
         seal_type = self.client.seal_status["type"]  # type: ignore -- bad type hints in stubs
-        initialize_response = self.client.sys.initialize(secret_shares=1, secret_threshold=1)
-        root_token = initialize_response["root_token"]
         if seal_type == "shamir":
-            return root_token, initialize_response["keys"][0]
-        return root_token, initialize_response["recovery_keys"][0]
+            initialize_response = self.client.sys.initialize(secret_shares=1, secret_threshold=1)
+            root_token, unseal_key = (
+                initialize_response["root_token"],
+                initialize_response["keys"][0],
+            )
+            return root_token, unseal_key
+        initialize_response = self.client.sys.initialize(recovery_shares=1, recovery_threshold=1)
+        root_token, recovery_key = (
+            initialize_response["root_token"],
+            initialize_response["recovery_keys"][0],
+        )
+        return root_token, recovery_key
 
     def is_initialized(self) -> bool:
         """Check if the vault unit is initialized."""

--- a/tests/integration/vault.py
+++ b/tests/integration/vault.py
@@ -32,19 +32,11 @@ class Vault:
     def initialize(self) -> Tuple[str, str]:
         """Initialize the vault unit and return the root token and unseal key."""
         seal_type = self.client.seal_status["type"]  # type: ignore -- bad type hints in stubs
+        initialize_response = self.client.sys.initialize(secret_shares=1, secret_threshold=1)
+        root_token = initialize_response["root_token"]
         if seal_type == "shamir":
-            initialize_response = self.client.sys.initialize(secret_shares=1, secret_threshold=1)
-            root_token, unseal_key = (
-                initialize_response["root_token"],
-                initialize_response["keys"][0],
-            )
-            return root_token, unseal_key
-        initialize_response = self.client.sys.initialize(recovery_shares=1, recovery_threshold=1)
-        root_token, recovery_key = (
-            initialize_response["root_token"],
-            initialize_response["recovery_keys"][0],
-        )
-        return root_token, recovery_key
+            return root_token, initialize_response["keys"][0]
+        return root_token, initialize_response["recovery_keys"][0]
 
     def is_initialized(self) -> bool:
         """Check if the vault unit is initialized."""

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -26,7 +26,9 @@ from charms.tls_certificates_interface.v3.tls_certificates import (
     CertificateCreationRequestEvent,
     ProviderCertificate,
 )
+from charms.vault_k8s.v0.vault_autounseal import AutounsealDetails
 from charms.vault_k8s.v0.vault_client import (
+    AppRole,
     AuditDeviceType,
     Certificate,
     SecretsBackend,
@@ -35,7 +37,7 @@ from charms.vault_k8s.v0.vault_client import (
     VaultClientError,
 )
 from charms.vault_k8s.v0.vault_s3 import S3, S3Error
-from charms.vault_k8s.v0.vault_tls import CA_CERTIFICATE_JUJU_SECRET_LABEL
+from charms.vault_k8s.v0.vault_tls import CA_CERTIFICATE_JUJU_SECRET_LABEL, VaultTLSManager
 
 S3_LIB_PATH = "charms.data_platform_libs.v0.s3"
 PEER_RELATION_NAME = "vault-peers"
@@ -46,6 +48,8 @@ TLS_CERTIFICATES_LIB_PATH = "charms.tls_certificates_interface.v3.tls_certificat
 VAULT_KV_LIB_PATH = "charms.vault_k8s.v0.vault_kv"
 TLS_CERTIFICATES_PKI_RELATION_NAME = "tls-certificates-pki"
 VAULT_KV_REQUIRER_APPLICATION_NAME = "vault-kv-requirer"
+VAULT_AUTOUNSEAL_LIB_PATH = "charms.vault_k8s.v0.vault_autounseal"
+AUTOUNSEAL_MOUNT_PATH = "charm-autounseal"
 
 
 class MockNetwork:
@@ -107,9 +111,9 @@ class TestConfigFileContentMatches(unittest.TestCase):
 
 class TestCharm(unittest.TestCase):
     patcher_snap_cache = patch("charm.snap.SnapCache")
-    patcher_vault_tls_manager = patch("charm.VaultTLSManager")
+    patcher_vault_tls_manager = patch("charm.VaultTLSManager", autospec=VaultTLSManager)
     patcher_machine = patch("charm.Machine")
-    patcher_vault = patch("charm.Vault")
+    patcher_vault = patch("charm.Vault", autospec=Vault)
 
     def setUp(self):
         self.mock_snap_cache = TestCharm.patcher_snap_cache.start()
@@ -229,13 +233,13 @@ class TestCharm(unittest.TestCase):
         )
         vault_snap.hold.assert_called()
 
-    @patch("charm.config_file_content_matches", new=Mock(return_value=False))
     @patch("ops.model.Model.get_binding")
     def test_given_config_file_not_exists_when_configure_then_config_file_pushed(
         self, patch_get_binding
     ):
         self.harness.set_leader(is_leader=True)
         self.harness.add_storage(storage_name="certs", attach=True)
+        self.mock_machine.exists.return_value = False
         expected_content_hcl = hcl.loads(read_file("tests/unit/config.hcl"))
         patch_get_binding.return_value = MockBinding(
             bind_address="1.2.1.2", ingress_address="2.3.2.3"
@@ -292,6 +296,7 @@ class TestCharm(unittest.TestCase):
         self,
         patch_get_binding,
     ):
+        self.mock_vault.configure_mock(**{"needs_migration.return_value": False})
         self.mock_machine.exists.return_value = False
         patch_get_binding.return_value = MockBinding(
             bind_address="1.2.1.2", ingress_address="2.3.2.3"
@@ -1454,7 +1459,7 @@ class TestCharm(unittest.TestCase):
 
         self.mock_vault.remove_raft_node.assert_called_once()
 
-    def test_given_when_on_remove_then_raft_dbs_are_removed(self):
+    def test_when_on_remove_then_raft_dbs_are_removed(self):
         self.harness.charm.on.remove.emit()
 
         self.mock_machine.remove_path.assert_has_calls(
@@ -1498,4 +1503,131 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(
             actual_config,
             [],
+        )
+
+    @patch("ops.testing._TestingPebbleClient.restart_services", new=MagicMock)
+    @patch(f"{VAULT_AUTOUNSEAL_LIB_PATH}.VaultAutounsealRequires.get_details")
+    def test_given_autounseal_details_available_when_autounseal_details_ready_then_transit_stanza_generated(  # noqa: E501
+        self,
+        mock_get_details,
+    ):
+        # Given
+        address = "some address"
+        key_name = "some key"
+        role_id = "role_id"
+        secret_id = "secret_id"
+        ca_cert = "ca_cert"
+        mock_get_details.return_value = AutounsealDetails(
+            address, key_name, role_id, secret_id, ca_cert
+        )
+        relation_id = self.harness.add_relation(
+            relation_name="vault-autounseal-requires", remote_app="autounseal-provider"
+        )
+        self.harness.add_storage(storage_name="config", attach=True)
+        self._set_peer_relation()
+        self.harness.update_relation_data(
+            app_or_unit=self.app_name,
+            relation_id=relation_id,
+            key_values={},
+        )
+        self.harness.set_leader()  # TODO: Why does this need to be set?
+        self.mock_machine.exists.return_value = False
+        self.mock_vault.token = "some token"
+
+        # When
+        self.harness.charm.vault_autounseal_requires.on.vault_autounseal_details_ready.emit(
+            address, key_name, role_id, secret_id, ca_cert
+        )
+
+        # Then
+        self.mock_machine.push.assert_called()
+        _, kwargs = self.mock_machine.push.call_args
+        assert kwargs["path"] == "/var/snap/vault/common/vault.hcl"
+        pushed_content_hcl = hcl.loads(kwargs["source"])
+        assert pushed_content_hcl["seal"]["transit"]["address"] == address
+        assert pushed_content_hcl["seal"]["transit"]["token"] == "some token"
+        assert pushed_content_hcl["seal"]["transit"]["key_name"] == "some key"
+        self.mock_vault.authenticate.assert_called_with(AppRole(role_id, secret_id))
+        self.mock_vault_tls_manager.push_autounseal_ca_cert.assert_called_with(ca_cert)
+
+    def _set_approle_secret(self, role_id: str, secret_id: str) -> None:
+        """Set the approle secret."""
+        content = {
+            "role-id": role_id,
+            "secret-id": secret_id,
+        }
+        original_leader_state = self.harness.charm.unit.is_leader()
+        with self.harness.hooks_disabled():
+            self.harness.set_leader(is_leader=True)
+            secret_id = self.harness.add_model_secret(owner=self.app_name, content=content)
+            secret = self.harness.model.get_secret(id=secret_id)
+            secret.set_info(label=VAULT_CHARM_APPROLE_SECRET_LABEL)
+            self.harness.set_leader(original_leader_state)
+
+    @patch(f"{VAULT_AUTOUNSEAL_LIB_PATH}.VaultAutounsealProvides.set_autounseal_data")
+    def test_when_autounseal_initialize_then_credentials_are_set(self, mock_set_autounseal_data):
+        # Given
+        self.mock_vault.configure_mock(
+            **{
+                "is_initialized.return_value": True,
+                "is_api_available.return_value": True,
+                "is_sealed.return_value": False,
+                "create_autounseal_credentials.return_value": (
+                    "key name",
+                    "autounseal role id",
+                    "autounseal secret id",
+                ),
+            },
+        )
+        self.mock_machine.exists.return_value = False
+        self.harness.set_leader()
+        self.harness.add_storage(storage_name="config", attach=True)
+        self._set_peer_relation()
+        self._set_approle_secret("role id", "secret id")
+        self.mock_vault_tls_manager.pull_tls_file_from_workload.return_value = "ca cert"
+        # Set the default network
+        self.harness.add_network("10.0.0.10")
+        # # When
+        relation_id = self.harness.add_relation(
+            relation_name="vault-autounseal-provides", remote_app="autounseal-requirer"
+        )
+
+        # Then
+        relation = self.harness.model.get_relation("vault-autounseal-provides", relation_id)
+        mock_set_autounseal_data.assert_called_once_with(
+            relation,
+            "https://10.0.0.10:8200",
+            "key name",
+            "autounseal role id",
+            "autounseal secret id",
+            "ca cert",
+        )
+
+    def test_when_autounseal_destroy_then_credentials_are_removed(self):
+        # Given
+        self.mock_vault.configure_mock(
+            **{
+                "is_initialized.return_value": True,
+                "is_api_available.return_value": True,
+            },
+        )
+        self.mock_machine.exists.return_value = False
+        self.harness.add_network("10.0.0.10")
+        self._set_approle_secret("role id", "secret id")
+        self._set_peer_relation()
+        self.harness.set_leader()
+        with self.harness.hooks_disabled():
+            relation_id = self.harness.add_relation(
+                relation_name="vault-autounseal-provides", remote_app="autounseal-requirer"
+            )
+            relation = self.harness.model.get_relation("vault-autounseal-provides", relation_id)
+
+        # When
+        self.harness.charm.vault_autounseal_provides.on.vault_autounseal_requirer_relation_broken.emit(
+            relation
+        )
+
+        # Then
+        self.mock_vault.destroy_autounseal_credentials.assert_called_once_with(
+            relation_id, AUTOUNSEAL_MOUNT_PATH
         )


### PR DESCRIPTION
# Description

Requires: https://github.com/canonical/vault-k8s-operator/pull/403

Implements the machine charm version of auto-unseal. See https://github.com/canonical/vault-k8s-operator/pull/365 for the k8s charm implementation. Usage is exactly the same as in the k8s charm, however, now cross-model relations are possible. In other words, you can use a machine Vault to unlock a k8s Vault (or vice-versa).

To do that:

1. Deploy your unsealer and autounsealed Vaults in different models.
2. Switch to the model with the unsealer, and offer your unsealer `vault-autounseal-provides` integration: `juju offer vault:vault-autounseal-provides`
3. Switch to the model with the autounsealed Vault, and consume the integration: `juju consume mycloud:admin/dev.vault`
4. Continue as in the k8s instructions above.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
