### PR TITLE
fix: Move certificate check before common name config check

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -925,13 +925,13 @@ class VaultOperatorCharm(CharmBase):
         if not (approle_auth := self._get_vault_approle_secret()):
             return
         vault.authenticate(AppRole(approle_auth[0], approle_auth[1]))
-        common_name = self._get_config_common_name()
-        if not common_name:
-            logger.error("Common name is not set in the charm config")
-            return
         certificate = self._get_pki_intermediate_ca_certificate()
         if not certificate:
             logger.debug("No certificate available")
+            return
+        common_name = self._get_config_common_name()
+        if not common_name:
+            logger.error("Common name is not set in the charm config")
             return
         if not self._is_intermediate_ca_common_name_valid(
             vault, common_name


### PR DESCRIPTION
This prevents constant error messages in the Juju logs about not having a common name set when you're not using PKI.

k8s charm: https://github.com/canonical/vault-k8s-operator/pull/394

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
