### PR TITLE
feat: enable usage of approle wrapping tokens

### DIFF
--- a/lib/charms/vault_k8s/v0/vault_client.py
+++ b/lib/charms/vault_k8s/v0/vault_client.py
@@ -11,7 +11,7 @@ import logging
 from abc import abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from typing import Dict, List, Optional, Protocol
+from typing import Dict, List, Optional, Protocol, Union
 
 import hvac
 import requests
@@ -289,6 +289,11 @@ class Vault:
         """Generate a new secret tied to an AppRole."""
         response = self._client.auth.approle.generate_secret_id(name, cidr_list=cidrs)
         return response["data"]["secret_id"]
+
+    def generate_role_wrapping_token(self, name: str, wrap_ttl: Union[int, str], cidrs: Optional[List[str]] = None) -> str:
+        """Generate a new wrapping token tied to an AppRole."""
+        response = self._client.auth.approle.generate_secret_id(name, cidr_list=cidrs, wrap_ttl=wrap_ttl)
+        return response["wrap_info"]["token"]
 
     def read_role_secret(self, name: str, id: str) -> dict:
         """Get definition of a secret tied to an AppRole."""

--- a/tests/integration/vault_kv_requirer_operator/src/charm.py
+++ b/tests/integration/vault_kv_requirer_operator/src/charm.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 class VaultKVRequirerCharm(CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
-        self.vault_kv = VaultKvRequires(self, "vault-kv", mount_suffix="kv")
+        self.vault_kv = VaultKvRequires(self, "vault-kv", mount_suffix="kv", wrap_ttl="120s")
         self.framework.observe(self.on.install, self._configure)
         self.framework.observe(self.vault_kv.on.connected, self._on_kv_connected)
         self.framework.observe(self.vault_kv.on.ready, self._on_kv_ready)
@@ -81,7 +81,7 @@ class VaultKVRequirerCharm(CharmBase):
             "vault-url": vault_url,
             "mount": mount,
             "role-id": secret_content["role-id"],
-            "role-secret-id": secret_content["role-secret-id"],
+            "wrapping-token": secret_content["wrapping-token"],
         }
         try:
             vault_kv_secret = self.model.get_secret(label=VAULT_KV_SECRET_LABEL)
@@ -120,7 +120,7 @@ class VaultKVRequirerCharm(CharmBase):
             url=secret_content["vault-url"],
             approle_role_id=secret_content["role-id"],
             ca_certificate=f"{ca_certificate_path}/{VAULT_CA_CERT_FILENAME}",
-            approle_secret_id=secret_content["role-secret-id"],
+            wrapping_token=secret_content["wrapping-token"],
         )
         vault.create_secret_in_kv(
             path=VAULT_KV_SECRET_PATH, mount=mount, key=secret_key, value=secret_value
@@ -146,7 +146,7 @@ class VaultKVRequirerCharm(CharmBase):
             url=secret_content["vault-url"],
             approle_role_id=secret_content["role-id"],
             ca_certificate=f"{ca_certificate_path}/{VAULT_CA_CERT_FILENAME}",
-            approle_secret_id=secret_content["role-secret-id"],
+            wrapping_token=secret_content["wrapping-token"],
         )
         vault_secret = vault.get_secret_in_kv(path=VAULT_KV_SECRET_PATH, mount=mount)
         if secret_key not in vault_secret:


### PR DESCRIPTION
# Description

This PR enables the usage of wrapping tokens by the Requirer application as something optional.

This PR will enable integration with charms that require a wrapping token instead of the role secret ID, like `maas-region`. MAAS can be integrated with Vault by providing approle details, as described in the relevant docs [section](https://maas.io/docs/how-to-integrate-vault).

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
