### PR TITLE
feat: include mount path in databag contents

### DIFF
--- a/lib/charms/tls_certificates_interface/v3/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v3/tls_certificates.py
@@ -277,13 +277,13 @@ juju relate <tls-certificates provider charm> <tls-certificates requirer charm>
 """  # noqa: D405, D410, D411, D214, D416
 
 import copy
+import ipaddress
 import json
 import logging
 import uuid
 from contextlib import suppress
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from ipaddress import IPv4Address
 from typing import List, Literal, Optional, Union
 
 from cryptography import x509
@@ -317,7 +317,7 @@ LIBAPI = 3
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 16
+LIBPATCH = 17
 
 PYDEPS = ["cryptography", "jsonschema"]
 
@@ -1077,7 +1077,7 @@ def generate_csr(  # noqa: C901
     if sans_oid:
         _sans.extend([x509.RegisteredID(x509.ObjectIdentifier(san)) for san in sans_oid])
     if sans_ip:
-        _sans.extend([x509.IPAddress(IPv4Address(san)) for san in sans_ip])
+        _sans.extend([x509.IPAddress(ipaddress.ip_address(san)) for san in sans_ip])
     if sans:
         _sans.extend([x509.DNSName(san) for san in sans])
     if sans_dns:

--- a/lib/charms/vault_k8s/v0/vault_autounseal.py
+++ b/lib/charms/vault_k8s/v0/vault_autounseal.py
@@ -79,7 +79,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 
 class LogAdapter(logging.LoggerAdapter):
@@ -99,6 +99,9 @@ class VaultAutounsealProviderSchema(BaseModel):
     """Provider side of the vault-autounseal relation interface."""
 
     address: str = Field(description="The address of the Vault server to connect to.")
+    mount_path: str = Field(
+        description="The path to the transit engine mount point where the key is stored."
+    )
     key_name: str = Field(description="The name of the transit key to use for autounseal.")
     credentials_secret_id: str = Field(
         description=(
@@ -119,9 +122,12 @@ class ProviderSchema(DataBagSchema):
 class VaultAutounsealDetailsReadyEvent(ops.EventBase):
     """Event emitted on the requirer when Vault autounseal details are ready in the databag."""
 
-    def __init__(self, handle: ops.Handle, address, key_name, role_id, secret_id, ca_certificate):
+    def __init__(
+        self, handle: ops.Handle, address, mount_path, key_name, role_id, secret_id, ca_certificate
+    ):
         super().__init__(handle)
         self.address = address
+        self.mount_path = mount_path
         self.key_name = key_name
         self.role_id = role_id
         self.secret_id = secret_id
@@ -132,6 +138,7 @@ class VaultAutounsealDetailsReadyEvent(ops.EventBase):
         return dict(
             super().snapshot(),
             address=self.address,
+            mount_path=self.mount_path,
             key_name=self.key_name,
             role_id=self.role_id,
             secret_id=self.secret_id,
@@ -142,6 +149,7 @@ class VaultAutounsealDetailsReadyEvent(ops.EventBase):
         """Restore the event from a snapshot."""
         super().restore(snapshot)
         self.address = snapshot["address"]
+        self.mount_path = snapshot["mount_path"]
         self.key_name = snapshot["key_name"]
         self.role_id = snapshot["role_id"]
         self.secret_id = snapshot["secret_id"]
@@ -231,6 +239,7 @@ class AutounsealDetails:
     """The details required to autounseal a vault instance."""
 
     address: str
+    mount_path: str
     key_name: str
     role_id: str
     secret_id: str
@@ -296,6 +305,7 @@ class VaultAutounsealProvides(ops.Object):
         self,
         relation: ops.Relation,
         vault_address: str,
+        mount_path: str,
         key_name: str,
         approle_role_id: str,
         approle_secret_id: str,
@@ -306,6 +316,7 @@ class VaultAutounsealProvides(ops.Object):
         Args:
             relation: The Juju relation to set the autounseal data in.
             vault_address: The address of the Vault server which will be used for autounseal
+            mount_path: The path to the transit engine mount point where the key is stored.
             key_name: The name of the transit key to use for autounseal.
             approle_role_id: The AppRole Role ID to use when authenticating with the external Vault server.
             approle_secret_id: The AppRole Secret ID to use when authenticating with the external Vault server.
@@ -328,6 +339,7 @@ class VaultAutounsealProvides(ops.Object):
         relation.data[self.charm.app].update(
             {
                 "address": vault_address,
+                "mount_path": mount_path,
                 "key_name": key_name,
                 "credentials_secret_id": credentials_secret_id,
                 "ca_certificate": ca_certificate,
@@ -427,6 +439,7 @@ class VaultAutounsealRequires(ops.Object):
                 return
             self.on.vault_autounseal_details_ready.emit(
                 details.address,
+                details.mount_path,
                 details.key_name,
                 details.role_id,
                 details.secret_id,
@@ -452,13 +465,15 @@ class VaultAutounsealRequires(ops.Object):
             return None
         data = relation.data[relation.app]
         address = data.get("address")
+        mount_path = data.get("mount_path")
         key_name = data.get("key_name")
         ca_certificate = data.get("ca_certificate")
         credentials = self._get_credentials(relation)
-        if not (address and key_name and ca_certificate and credentials):
+        if not (address and mount_path and key_name and ca_certificate and credentials):
             return None
         return AutounsealDetails(
             address,
+            mount_path,
             key_name,
             credentials.role_id,
             credentials.secret_id,

--- a/src/charm.py
+++ b/src/charm.py
@@ -367,6 +367,7 @@ class VaultOperatorCharm(CharmBase):
         self.vault_autounseal_provides.set_autounseal_data(
             relation,
             vault_address,
+            AUTOUNSEAL_MOUNT_PATH,
             key_name,
             approle_id,
             approle_secret_id,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1532,7 +1532,7 @@ class TestCharm(unittest.TestCase):
         secret_id = "secret_id"
         ca_cert = "ca_cert"
         mock_get_details.return_value = AutounsealDetails(
-            address, key_name, role_id, secret_id, ca_cert
+            address, AUTOUNSEAL_MOUNT_PATH, key_name, role_id, secret_id, ca_cert
         )
         relation_id = self.harness.add_relation(
             relation_name="vault-autounseal-requires", remote_app="autounseal-provider"
@@ -1550,7 +1550,7 @@ class TestCharm(unittest.TestCase):
 
         # When
         self.harness.charm.vault_autounseal_requires.on.vault_autounseal_details_ready.emit(
-            address, key_name, role_id, secret_id, ca_cert
+            address, AUTOUNSEAL_MOUNT_PATH, key_name, role_id, secret_id, ca_cert
         )
 
         # Then
@@ -1559,8 +1559,9 @@ class TestCharm(unittest.TestCase):
         assert kwargs["path"] == "/var/snap/vault/common/vault.hcl"
         pushed_content_hcl = hcl.loads(kwargs["source"])
         assert pushed_content_hcl["seal"]["transit"]["address"] == address
-        assert pushed_content_hcl["seal"]["transit"]["token"] == "some token"
+        assert pushed_content_hcl["seal"]["transit"]["mount_path"] == AUTOUNSEAL_MOUNT_PATH
         assert pushed_content_hcl["seal"]["transit"]["key_name"] == "some key"
+        assert pushed_content_hcl["seal"]["transit"]["token"] == "some token"
         self.mock_vault.authenticate.assert_called_with(AppRole(role_id, secret_id))
         self.mock_vault_tls_manager.push_autounseal_ca_cert.assert_called_with(ca_cert)
 
@@ -1597,6 +1598,7 @@ class TestCharm(unittest.TestCase):
         mock_set_autounseal_data.assert_called_once_with(
             relation,
             "https://10.0.0.10:8200",
+            AUTOUNSEAL_MOUNT_PATH,
             "key name",
             "autounseal role id",
             "autounseal secret id",


### PR DESCRIPTION
There's no need to infer the mount path, and adding it makes the interface more flexible.

This also bumps the libraries to their latest versions.

This conforms with the interface described in https://github.com/canonical/charm-relation-interfaces/tree/main/interfaces/vault_autounseal/v0

k8s charm version: https://github.com/canonical/vault-k8s-operator/pull/406

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
