### PR TITLE
feat: Use juju secrets instead for authorize-charm 

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -116,15 +116,17 @@ actions:
     description: >-
       Authorizes the charm to be able to interact with Vault to manage its
       operations. A token is required for Vault to use to create the app role and
-      the policy the charm will use to interact with Vault.
+      the policy the charm will use to interact with Vault. This token must be
+      placed in juju secret, and this secret should be granted to the charm.
     params:
-      token:
+      secret-id:
         type: string
         description: >-
-          A token for Vault that can create new policies, such as the root token
-          that is provided upon initializing Vault. Used to create the app role
-          and policy for the charm. It is not stored by the charm.
-    required: [token]
+          A secret id from juju that contains a token for Vault that can create 
+          new policies, such as the root token that is provided upon initializing 
+          Vault. Used to create the app role and policy for the charm. It is not
+          stored by the charm.
+    required: [secret-id] 
 
   create-backup:
     description: >-

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -344,11 +344,14 @@ async def authorize_charm(
         Action output
     """
     assert ops_test.model
+    secret = await ops_test.model.add_secret(f"approle-token-{app_name}", [f"token={root_token}"])
+    secret_id = secret.split(":")[-1]
+    await ops_test.model.grant_secret(f"approle-token-{app_name}", app_name)
     leader_unit = await get_leader_unit(ops_test.model, app_name)
     authorize_action = await leader_unit.run_action(
         action_name="authorize-charm",
         **{
-            "token": root_token,
+            "secret-id": secret_id,
         },
     )
     result = await ops_test.model.get_action_output(


### PR DESCRIPTION
# Description

This change includes moving from using an action to authorize the charm to granting a user secret to authorizing a charm. The process is simply:

```shell
juju add-secret approle_authorization_token token=$VAULT_TOKEN
juju grant-secret approle_authorization_token vault-k8s
juju config vault-k8s approle_token_secret_id=$(juju show-secret approle_authorization_token | yq 'to_entries[]' | yq .key)
```
The documentation will need to be updated.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
