### PR TITLE
test: Fix integration tests for latest tls requirer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ extend-ignore = [
     "D409",
     "D413",
     "D107",
+    "E501",
 ]
 per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
 


### PR DESCRIPTION
After publishing a new version of the tls requirer, the integration tests will fail. This change resolves those issues.
# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
