### PR TITLE
fix: Pins pytest-asyncio to prevent pytest issues

### DIFF
--- a/test-requirements.in
+++ b/test-requirements.in
@@ -4,4 +4,5 @@ juju
 pyright
 pytest
 pytest-operator
+pytest-asyncio==0.21.2
 ruff


### PR DESCRIPTION
# Description

There is a known [issue](https://github.com/pytest-dev/pytest/issues/12269) that happens when `pytest-asyncio==0.21.1` is used with `pytest>8.2.0`. In this PR we pin `pytest-asyncio` to 0.21.2 so unblock dependabot prs.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
