### PR TITLE
fix: Access kv secret using secret ID

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -904,6 +904,9 @@ class VaultOperatorCharm(CharmBase):
         )
         role_secret_id = vault.generate_role_secret_id(name=role_name, cidrs=[egress_subnet])
         current_credentials = self.vault_kv.get_credentials(relation)
+        # TODO bug: https://bugs.launchpad.net/juju/+bug/2075153
+        # Until the reference bug is fixed we must pass the secret ID here
+        # not to lose the secret://modeluuid:secretID format
         secret = self._create_or_update_kv_secret(
             role_name=role_name,
             role_id=role_id,


### PR DESCRIPTION
# Description

fixes https://github.com/canonical/vault-operator/issues/243

Not to lose the `secret://modeluuid/standard_secret_id` format of the secret ID which is required to access the secret in cross model relations we get the secret with the secret ID that was initially returned by `add_secret` and initially stored in the relation databag.

Bug reported in Juju https://bugs.launchpad.net/juju/+bug/2075153

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
