### PR TITLE
fix: Uses egress subnet list to configure approle

### DIFF
--- a/lib/charms/vault_k8s/v0/vault_kv.py
+++ b/lib/charms/vault_k8s/v0/vault_kv.py
@@ -94,7 +94,7 @@ class ExampleRequirerCharm(CharmBase):
         # Update status might not be the best place
         binding = self.model.get_binding("vault-kv")
         if binding is not None:
-            egress_subnet = str(binding.network.interfaces[0].subnet)
+            egress_subnet = [str(subnet) for subnet in self.model.get_binding(relation).network.egress_subnets][0].subnet]
             relation = self.model.get_relation(relation_name="vault-kv")
             self.interface.request_credentials(relation, egress_subnet, self.get_nonce())
 

--- a/lib/charms/vault_k8s/v0/vault_kv.py
+++ b/lib/charms/vault_k8s/v0/vault_kv.py
@@ -219,6 +219,17 @@ class KVRequest:
     nonce: str
 
 
+def get_egress_subnets_list_from_relation_data(relation_databag: Mapping[str, str]) -> List[str]:
+    """Return the egress_subnet as a list.
+
+    This function converts the string with values separated by commas to a list.
+
+    Args:
+        relation_databag: the relation databag of the unit or the app.
+    """
+    return [subnet.strip() for subnet in relation_databag.get("egress_subnet", "").split(",")]
+
+
 def is_requirer_data_valid(app_data: Mapping[str, str], unit_data: Mapping[str, str]) -> bool:
     """Return whether the requirer data is valid."""
     try:
@@ -339,7 +350,9 @@ class VaultKvProvides(ops.Object):
                 app_name=event.app.name,
                 unit_name=unit.name,
                 mount_suffix=event.relation.data[event.app]["mount_suffix"],
-                egress_subnets=event.relation.data[unit]["egress_subnet"].split(","),
+                egress_subnets=get_egress_subnets_list_from_relation_data(
+                    event.relation.data[unit]
+                ),
                 nonce=event.relation.data[unit]["nonce"],
             )
 
@@ -458,7 +471,7 @@ class VaultKvProvides(ops.Object):
                         app_name=relation.app.name,
                         unit_name=unit.name,
                         mount_suffix=app_data["mount_suffix"],
-                        egress_subnets=unit_data["egress_subnet"].split(","),
+                        egress_subnets=get_egress_subnets_list_from_relation_data(unit_data),
                         nonce=unit_data["nonce"],
                     )
                 )

--- a/src/charm.py
+++ b/src/charm.py
@@ -872,7 +872,7 @@ class VaultOperatorCharm(CharmBase):
         app_name: str,
         unit_name: str,
         mount_suffix: str,
-        egress_subnet: str,
+        egress_subnet: List[str],
         nonce: str,
     ):
         if not self.unit.is_leader():
@@ -898,11 +898,11 @@ class VaultOperatorCharm(CharmBase):
         role_id = vault.configure_approle(
             role_name=role_name,
             policies=[policy_name],
-            cidrs=[egress_subnet],
+            cidrs=egress_subnet,
             token_ttl="1h",
             token_max_ttl="1h",
         )
-        role_secret_id = vault.generate_role_secret_id(name=role_name, cidrs=[egress_subnet])
+        role_secret_id = vault.generate_role_secret_id(name=role_name, cidrs=egress_subnet)
         current_credentials = self.vault_kv.get_credentials(relation)
         # TODO bug: https://bugs.launchpad.net/juju/+bug/2075153
         # Until the reference bug is fixed we must pass the secret ID here

--- a/src/charm.py
+++ b/src/charm.py
@@ -605,7 +605,7 @@ class VaultOperatorCharm(CharmBase):
             app_name=event.app_name,
             unit_name=event.unit_name,
             mount_suffix=event.mount_suffix,
-            egress_subnet=event.egress_subnet,
+            egress_subnets=event.egress_subnets,
             nonce=event.nonce,
         )
 
@@ -872,7 +872,7 @@ class VaultOperatorCharm(CharmBase):
         app_name: str,
         unit_name: str,
         mount_suffix: str,
-        egress_subnet: List[str],
+        egress_subnets: List[str],
         nonce: str,
     ):
         if not self.unit.is_leader():
@@ -898,11 +898,11 @@ class VaultOperatorCharm(CharmBase):
         role_id = vault.configure_approle(
             role_name=role_name,
             policies=[policy_name],
-            cidrs=egress_subnet,
+            cidrs=egress_subnets,
             token_ttl="1h",
             token_max_ttl="1h",
         )
-        role_secret_id = vault.generate_role_secret_id(name=role_name, cidrs=egress_subnet)
+        role_secret_id = vault.generate_role_secret_id(name=role_name, cidrs=egress_subnets)
         current_credentials = self.vault_kv.get_credentials(relation)
         # TODO bug: https://bugs.launchpad.net/juju/+bug/2075153
         # Until the reference bug is fixed we must pass the secret ID here
@@ -917,7 +917,7 @@ class VaultOperatorCharm(CharmBase):
         self.vault_kv.set_mount(relation, mount)
         self.vault_kv.set_ca_certificate(relation, ca_certificate)
         self.vault_kv.set_vault_url(relation, vault_url)
-        self.vault_kv.set_egress_subnet(relation, egress_subnet)
+        self.vault_kv.set_egress_subnets(relation, egress_subnets)
         self.vault_kv.set_unit_credentials(relation, nonce, secret)
         credential_nonces = self.vault_kv.get_credentials(relation).keys()
         if nonce not in set(credential_nonces):
@@ -993,7 +993,7 @@ class VaultOperatorCharm(CharmBase):
                 app_name=kv_request.app_name,
                 unit_name=kv_request.unit_name,
                 mount_suffix=kv_request.mount_suffix,
-                egress_subnet=kv_request.egress_subnet,
+                egress_subnets=kv_request.egress_subnets,
                 nonce=kv_request.nonce,
             )
 

--- a/tests/integration/vault_kv_requirer_operator/src/charm.py
+++ b/tests/integration/vault_kv_requirer_operator/src/charm.py
@@ -58,8 +58,9 @@ class VaultKVRequirerCharm(CharmBase):
         if not binding:
             logger.error("Binding not found")
             return
-        egress_subnet = [str(subnet) for subnet in binding.network.egress_subnets]
-        self.vault_kv.request_credentials(relation, egress_subnet, self.get_nonce())
+        egress_subnets = [str(subnet) for subnet in binding.network.egress_subnets]
+        egress_subnets.append(str(binding.network.interfaces[0].subnet))
+        self.vault_kv.request_credentials(relation, egress_subnets, self.get_nonce())
 
     def _on_kv_ready(self, event: VaultKvReadyEvent):
         """Store the Vault KV credentials in a secret."""

--- a/tests/integration/vault_kv_requirer_operator/src/charm.py
+++ b/tests/integration/vault_kv_requirer_operator/src/charm.py
@@ -58,7 +58,7 @@ class VaultKVRequirerCharm(CharmBase):
         if not binding:
             logger.error("Binding not found")
             return
-        egress_subnet = str(binding.network.interfaces[0].subnet)
+        egress_subnet = [str(subnet) for subnet in binding.network.egress_subnets]
         self.vault_kv.request_credentials(relation, egress_subnet, self.get_nonce())
 
     def _on_kv_ready(self, event: VaultKvReadyEvent):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -230,13 +230,13 @@ class TestCharm(unittest.TestCase):
         self.harness.set_leader()
         rel_id = self.harness.add_relation(relation_name, app_name)
         unit_name = app_name + "/0"
-        egress_subnet = "10.20.20.20/32"
+        egress_subnets = "10.20.20.20/32"
         self.harness.add_relation_unit(rel_id, unit_name)
         self.harness.update_relation_data(
-            rel_id, unit_name, {"egress_subnet": egress_subnet, "nonce": "0"}
+            rel_id, unit_name, {"egress_subnets": egress_subnets, "nonce": "0"}
         )
 
-        return (rel_id, egress_subnet)
+        return (rel_id, egress_subnets)
 
     @patch("charm.config_file_content_matches", new=Mock())
     @patch("ops.model.Model.get_binding")
@@ -964,7 +964,7 @@ class TestCharm(unittest.TestCase):
         event.app_name = VAULT_KV_REQUIRER_APPLICATION_NAME
         event.unit_name = f"{VAULT_KV_REQUIRER_APPLICATION_NAME}/0"
         event.mount_suffix = "suffix"
-        event.egress_subnet = ["2.2.2.0/24"]
+        event.egress_subnets = ["2.2.2.0/24"]
         event.nonce = "123123"
 
         self.harness.charm._on_new_vault_kv_client_attached(event)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -964,7 +964,7 @@ class TestCharm(unittest.TestCase):
         event.app_name = VAULT_KV_REQUIRER_APPLICATION_NAME
         event.unit_name = f"{VAULT_KV_REQUIRER_APPLICATION_NAME}/0"
         event.mount_suffix = "suffix"
-        event.egress_subnet = "2.2.2.0/24"
+        event.egress_subnet = ["2.2.2.0/24"]
         event.nonce = "123123"
 
         self.harness.charm._on_new_vault_kv_client_attached(event)


### PR DESCRIPTION
# Description

Fixes https://github.com/canonical/vault-operator/issues/244

**Note1**: Should not be merged before https://github.com/canonical/vault-k8s-operator/pull/450

**Note2**: This is a breaking change on the provider side, but since this is handled in the same PR in Vault I think it should be okay. No breaking changes on the requirer side by allowing it to set the egress subnet as string or as list.

Instead of using the `interfaces` of the network binding to configure the approle in vault we use the list of `egress_subnets`.
Juju describes the interfaces as:
```
A list of network interface details. This includes the information
    about how the application should be configured (for example, what IP
    addresses should be bound to).
```

While it describes the `egress_subnets` to be:
```
A list of networks representing the subnets that other units will see
    the charm connecting from. Due to things like NAT it isn't always possible to
    narrow it down to a single address, but when it is clear, the CIDRs will
    be constrained to a single address (for example, 10.0.0.1/32).
```

A solution as simple as changing the example docstring in the lib to `str(self.model.get_binding(relation).network.egress_subnets][0].subnet)` could have been enough, however this solution that introduces lists is based on the `Due to things like NAT it isn't always possible to
    narrow it down to a single address, but when it is clear, the CIDRs will
    be constrained to a single address (for example, 10.0.0.1/32)` part of the documentation of the `egress_subnets` 

This change will allow the charm to respect the `--via` option when related in juju, this is important when Vault is related to a kv requirer that is deployed in a different model.


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
