### PR TITLE
fix: Install and run the new version of the snap on the machine when Vault is updated.

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -1222,7 +1222,7 @@ class VaultOperatorCharm(CharmBase):
         try:
             snap_cache = snap.SnapCache()
             vault_snap = snap_cache[VAULT_SNAP_NAME]
-            if vault_snap.latest:
+            if VAULT_SNAP_REVISION == vault_snap.revision:
                 return
             with self.temp_maintenance_status("Installing Vault"):
                 vault_snap.ensure(
@@ -1230,6 +1230,9 @@ class VaultOperatorCharm(CharmBase):
                 )
                 vault_snap.hold()
             logger.info("Vault snap installed")
+            if self._vault_service_is_running():
+                self.machine.restart(VAULT_SNAP_NAME)
+                logger.debug("Vault service restarted")
         except snap.SnapError as e:
             logger.error("An exception occurred when installing Vault. Reason: %s", str(e))
             raise e

--- a/src/charm.py
+++ b/src/charm.py
@@ -1231,8 +1231,8 @@ class VaultOperatorCharm(CharmBase):
                 vault_snap.hold()
             logger.info("Vault snap installed")
             if self._vault_service_is_running():
-                self.machine.restart(VAULT_SNAP_NAME)
-                logger.debug("Vault service restarted")
+                self.machine.stop(VAULT_SNAP_NAME)
+                logger.debug("Previously running Vault service stopped")
         except snap.SnapError as e:
             logger.error("An exception occurred when installing Vault. Reason: %s", str(e))
             raise e

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -284,7 +284,7 @@ class TestCharm(unittest.TestCase):
 
     @patch("charm.config_file_content_matches", new=Mock())
     @patch("ops.model.Model.get_binding")
-    def test_given_vault_snap_new_version_installed_when_configure_then_service_restarted(
+    def test_given_vault_snap_new_version_installed_when_configure_then_service_stopped(
         self, patch_get_binding: MagicMock
     ):
         self.harness.set_leader(is_leader=True)
@@ -303,7 +303,7 @@ class TestCharm(unittest.TestCase):
             SnapState.Latest, channel="1.16/stable", revision="2300"
         )
         vault_snap.hold.assert_called()
-        self.mock_machine.restart.assert_has_calls([call("vault"), call("vault")])
+        self.mock_machine.stop.assert_has_calls([call("vault")])
 
     @patch("ops.model.Model.get_binding")
     def test_given_config_file_not_exists_when_configure_then_config_file_pushed(

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -303,9 +303,7 @@ class TestCharm(unittest.TestCase):
             SnapState.Latest, channel="1.16/stable", revision="2300"
         )
         vault_snap.hold.assert_called()
-        self.mock_machine.restart.assert_has_calls(
-            [call("vault"), call("vault")]
-        )
+        self.mock_machine.restart.assert_has_calls([call("vault"), call("vault")])
 
     @patch("ops.model.Model.get_binding")
     def test_given_config_file_not_exists_when_configure_then_config_file_pushed(

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -244,7 +244,7 @@ class TestCharm(unittest.TestCase):
         self, patch_get_binding: MagicMock
     ):
         self.harness.set_leader(is_leader=True)
-        vault_snap = MagicMock(spec=Snap, latest=False)
+        vault_snap = MagicMock(spec=Snap, revision="1.16/stable")
         snap_cache = {"vault": vault_snap}
         self.mock_snap_cache.return_value = snap_cache
         self._set_peer_relation()
@@ -259,6 +259,53 @@ class TestCharm(unittest.TestCase):
             SnapState.Latest, channel="1.16/stable", revision="2300"
         )
         vault_snap.hold.assert_called()
+
+    @patch("charm.config_file_content_matches", new=Mock())
+    @patch("ops.model.Model.get_binding")
+    def test_given_vault_snap_old_snap_installed_when_configure_then_new_vault_snap_installed(
+        self, patch_get_binding: MagicMock
+    ):
+        self.harness.set_leader(is_leader=True)
+        vault_snap = MagicMock(spec=Snap, latest=True, revision="1.15/stable")
+        snap_cache = {"vault": vault_snap}
+        self.mock_snap_cache.return_value = snap_cache
+        self._set_peer_relation()
+        patch_get_binding.return_value = MockBinding(
+            bind_address="1.2.1.2", ingress_address="2.3.2.3"
+        )
+
+        self.harness.charm.on.install.emit()
+
+        self.mock_snap_cache.assert_called_with()
+        vault_snap.ensure.assert_called_with(
+            SnapState.Latest, channel="1.16/stable", revision="2300"
+        )
+        vault_snap.hold.assert_called()
+
+    @patch("charm.config_file_content_matches", new=Mock())
+    @patch("ops.model.Model.get_binding")
+    def test_given_vault_snap_new_version_installed_when_configure_then_service_restarted(
+        self, patch_get_binding: MagicMock
+    ):
+        self.harness.set_leader(is_leader=True)
+        vault_snap = MagicMock(spec=Snap, latest=True, revision="1.16/stable")
+        snap_cache = {"vault": vault_snap}
+        self.mock_snap_cache.return_value = snap_cache
+        self._set_peer_relation()
+        patch_get_binding.return_value = MockBinding(
+            bind_address="1.2.1.2", ingress_address="2.3.2.3"
+        )
+
+        self.harness.charm.on.install.emit()
+
+        self.mock_snap_cache.assert_called_with()
+        vault_snap.ensure.assert_called_with(
+            SnapState.Latest, channel="1.16/stable", revision="2300"
+        )
+        vault_snap.hold.assert_called()
+        self.mock_machine.restart.assert_has_calls(
+            [call("vault"), call("vault")]
+        )
 
     @patch("ops.model.Model.get_binding")
     def test_given_config_file_not_exists_when_configure_then_config_file_pushed(


### PR DESCRIPTION
# Description

- If the charm is deployed on a machine that has the vault snap already installed and running, it won't install it again even if a different version is required, a good example is when `juju refresh <charm>` is used.
In this PR we make sure the underlying machine has the required snap.
- This restarts vault if a new snap is installed so we start running using the new snap.
- Adds tests


# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
