### PR TITLE
refactor: Use `| None` instead of `Optional`

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -11,7 +11,7 @@ import logging
 import socket
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 import hcl
 from charms.data_platform_libs.v0.s3 import S3Requirer
@@ -114,7 +114,7 @@ def _render_vault_config_file(
     raft_storage_path: str,
     node_id: str,
     retry_joins: List[Dict[str, str]],
-    autounseal_details: Optional[AutounsealConfigurationDetails] = None,
+    autounseal_details: AutounsealConfigurationDetails | None = None,
 ) -> str:
     jinja2_environment = Environment(loader=FileSystemLoader(CONFIG_TEMPLATE_DIR_PATH))
     template = jinja2_environment.get_template(CONFIG_TEMPLATE_NAME)
@@ -299,7 +299,7 @@ class VaultOperatorCharm(CharmBase):
             return
         vault.destroy_autounseal_credentials(event.relation.id, AUTOUNSEAL_MOUNT_PATH)
 
-    def _get_active_vault_client(self) -> Optional[Vault]:
+    def _get_active_vault_client(self) -> Vault | None:
         """Return an initialized vault client.
 
         Returns:
@@ -395,7 +395,7 @@ class VaultOperatorCharm(CharmBase):
             ca_cert,
         )
 
-    def generate_vault_scrape_configs(self) -> Optional[List[Dict]]:
+    def generate_vault_scrape_configs(self) -> List[Dict] | None:
         """Generate the scrape configs for the COS agent.
 
         Returns:
@@ -828,7 +828,7 @@ class VaultOperatorCharm(CharmBase):
         if vault.is_node_in_raft_peers(node_id=self._node_id) and vault.get_num_raft_peers() > 1:
             vault.remove_raft_node(node_id=self._node_id)
 
-    def _check_s3_pre_requisites(self) -> Optional[str]:
+    def _check_s3_pre_requisites(self) -> str | None:
         """Check if the S3 pre-requisites are met."""
         if not self.unit.is_leader():
             return "Only leader unit can perform backup operations"
@@ -931,8 +931,8 @@ class VaultOperatorCharm(CharmBase):
         self,
         label: str,
         content: Dict[str, str],
-        description: Optional[str] = None,
-        id: Optional[str] = None,
+        description: str | None = None,
+        id: str | None = None,
     ) -> Secret:
         """Set the secret content at `label`, overwrite if it already exists.
 
@@ -949,7 +949,7 @@ class VaultOperatorCharm(CharmBase):
         secret.set_content(content)
         return secret
 
-    def _get_relation_api_address(self, relation: Relation) -> Optional[str]:
+    def _get_relation_api_address(self, relation: Relation) -> str | None:
         """Fetch the api address from relation and returns it.
 
         Example: "https://10.152.183.20:8200"
@@ -1142,7 +1142,7 @@ class VaultOperatorCharm(CharmBase):
         """
         return bool(self.model.get_relation(relation_name))
 
-    def _get_vault_approle(self) -> Optional[AppRole]:
+    def _get_vault_approle(self) -> AppRole | None:
         """Get the approle details from the secret.
 
         Returns:
@@ -1200,7 +1200,7 @@ class VaultOperatorCharm(CharmBase):
         vault_snap.start(services=["vaultd"])
         logger.debug("Vault service started")
 
-    def _get_autounseal_configuration(self) -> Optional[AutounsealConfigurationDetails]:
+    def _get_autounseal_configuration(self) -> AutounsealConfigurationDetails | None:
         """Retrieve the autounseal configuration details, if available.
 
         Returns the autounseal configuration details if all the required
@@ -1244,7 +1244,7 @@ class VaultOperatorCharm(CharmBase):
             self._set_juju_secret(AUTOUNSEAL_TOKEN_SECRET_LABEL, {"token": vault.token})
         return vault.token
 
-    def _get_juju_secret_field(self, label: str, field: str) -> Optional[str]:
+    def _get_juju_secret_field(self, label: str, field: str) -> str | None:
         """Retrieve the latest revision of the secret content from Juju.
 
         Args:
@@ -1355,7 +1355,7 @@ class VaultOperatorCharm(CharmBase):
         return f"{KV_SECRET_PREFIX}{unit_name_dash}"
 
     @property
-    def _bind_address(self) -> Optional[str]:
+    def _bind_address(self) -> str | None:
         """Fetches bind address from peer relation and returns it.
 
         Returns:
@@ -1373,7 +1373,7 @@ class VaultOperatorCharm(CharmBase):
             return None
 
     @property
-    def _api_address(self) -> Optional[str]:
+    def _api_address(self) -> str | None:
         """Returns the IP with the https schema and vault port.
 
         Example: "https://1.2.3.4:8200"
@@ -1383,7 +1383,7 @@ class VaultOperatorCharm(CharmBase):
         return f"https://{self._bind_address}:{VAULT_PORT}"
 
     @property
-    def _cluster_address(self) -> Optional[str]:
+    def _cluster_address(self) -> str | None:
         """Return the IP with the https schema and vault port.
 
         Example: "https://1.2.3.4:8201"

--- a/src/machine.py
+++ b/src/machine.py
@@ -9,7 +9,7 @@ import os
 import shutil
 import signal
 from pathlib import Path
-from typing import Optional, TextIO
+from typing import TextIO
 
 import psutil
 from charms.operator_libs_linux.v2 import snap
@@ -110,7 +110,7 @@ class Machine(WorkloadBase):
             os.kill(pid, signal.SIGTERM)
             logger.info("Stopped process %s", process)
 
-    def get_service(self, process: str) -> Optional[psutil.Process]:
+    def get_service(self, process: str) -> psutil.Process | None:
         """Get a service.
 
         Args:
@@ -123,7 +123,7 @@ class Machine(WorkloadBase):
             return psutil.Process(pid)
         return None
 
-    def _find_process(self, process: str) -> Optional[int]:
+    def _find_process(self, process: str) -> int | None:
         """Find a process.
 
         Args:

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -6,7 +6,7 @@ import logging
 import time
 from base64 import b64decode
 from pathlib import Path
-from typing import List, Optional
+from typing import List
 
 import yaml
 from juju.application import Application
@@ -49,7 +49,7 @@ def has_relation(app: Application, relation_name) -> bool:
     return False
 
 
-async def get_ca_cert_file_location(ops_test: OpsTest, app_name: str = APP_NAME) -> Optional[str]:
+async def get_ca_cert_file_location(ops_test: OpsTest, app_name: str = APP_NAME) -> str | None:
     """Get the location of the CA certificate file."""
     assert ops_test.model
     app = get_app(ops_test.model, app_name)
@@ -94,7 +94,7 @@ async def get_leader(app: Application) -> Unit:
 
 
 async def unseal_all_vault_units(
-    ops_test: OpsTest, ca_file_name: Optional[str], unseal_key: str
+    ops_test: OpsTest, ca_file_name: str | None, unseal_key: str
 ) -> None:
     """Unseal all the vault units."""
     assert ops_test.model
@@ -237,11 +237,6 @@ async def deploy_vault_and_wait(ops_test: OpsTest, charm_path, num_units) -> Non
 
 
 async def get_leader_unit_address(ops_test: OpsTest) -> str:
-    """Get the address of the leader unit.
-
-    Returns:
-        Optional[str]: The address of the leader unit
-    """
     assert ops_test.model
     app = ops_test.model.applications[APP_NAME]
     assert isinstance(app, Application)
@@ -253,11 +248,11 @@ async def get_leader_unit_address(ops_test: OpsTest) -> str:
 async def deploy_if_not_exists(
     model: Model,
     app_name: str,
-    charm_path: Optional[Path] = None,
+    charm_path: Path | None = None,
     num_units: int = 1,
-    config: Optional[dict] = None,
-    channel: Optional[str] = None,
-    revision: Optional[int] = None,
+    config: dict | None = None,
+    channel: str | None = None,
+    revision: int | None = None,
 ) -> None:
     if app_name not in model.applications:
         try:

--- a/tests/integration/vault.py
+++ b/tests/integration/vault.py
@@ -7,7 +7,7 @@
 import logging
 import time
 from os.path import abspath
-from typing import Optional, Tuple
+from typing import Tuple
 
 import hvac
 
@@ -20,9 +20,7 @@ VAULT_STATUS_NOT_INITIALIZED = 501
 
 
 class Vault:
-    def __init__(
-        self, url: str, ca_file_location: Optional[str] = None, token: Optional[str] = None
-    ):
+    def __init__(self, url: str, ca_file_location: str | None = None, token: str | None = None):
         self.url = url
         verify = abspath(ca_file_location) if ca_file_location else False
         self.client = hvac.Client(url=self.url, verify=verify)

--- a/tests/integration/vault_kv_requirer_operator/src/charm.py
+++ b/tests/integration/vault_kv_requirer_operator/src/charm.py
@@ -5,7 +5,6 @@
 import logging
 import secrets
 from pathlib import Path
-from typing import Optional
 
 from charms.vault_k8s.v0.vault_kv import (
     VaultKvConnectedEvent,
@@ -160,7 +159,7 @@ class VaultKVRequirerCharm(CharmBase):
         secret = self.model.get_secret(label=NONCE_SECRET_LABEL)
         return secret.get_content(refresh=True)["nonce"]
 
-    def _get_ca_cert_location_in_charm(self) -> Optional[Path]:
+    def _get_ca_cert_location_in_charm(self) -> Path | None:
         """Return the CA certificate location in the charm (not in the workload).
 
         This path would typically be: /var/lib/juju/storage/certs/0/ca.pem


### PR DESCRIPTION
k8s version: https://github.com/canonical/vault-k8s-operator/pull/465

Justification, copied from above:

- `Optional` was a poor choice of words. It doesn't fit well in all contexts and it conflicts with the already established meaning of an optional argument (you can have an optional argument that isn't optional).
- `Optional` also makes a lot less sense from an English perspective when it's a return value.
- It's easier to read (subjective)
- It's the new way, and new things are _always_ better,
- Also removes use of `Union`


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
