### PR TITLE
fix: Fix CI flakiness by rolling back concierge and preventing pytest-asyncio updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -25,6 +25,12 @@
       "groupName": "Python dependencies"
     },
     {
+      // Bumping "pytest-asyncio" over 0.23 breaks the integration tests
+      "matchPackageNames": ["pytest-asyncio"],
+      "matchUpdateTypes": ["minor"],
+      "enabled": false
+    },
+    {
       "matchManagers": ["github-actions"],
       "groupName": "GitHub actions"
     },

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -30,16 +30,17 @@ jobs:
         run: echo "charm_path=$(find kv-requirer/ -name '*.charm' -type f -print)" >> $GITHUB_OUTPUT
     
       - name: Setup operator environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          juju-channel: 3.5/stable
+          provider: lxd
+          lxd-channel: 5.21/stable
+
+      - name: Install UV and Tox
         run: |
-          sudo snap install concierge --classic
-          sudo concierge prepare -p machine --juju-channel "3.5/stable" --lxd-channel "5.21/stable" --extra-snaps astral-uv/latest/stable
+          python3 -m pip uninstall tox -y
+          sudo snap install astral-uv --classic
           uv tool install tox --with tox-uv
-
-      - name: Install uv
-        run: sudo snap install --classic astral-uv
-
-      - name: Install tox
-        run: uv tool install tox --with tox-uv
 
       - name: Run integration tests
         run: |


### PR DESCRIPTION
# Description

Rollback concierge introduction to fix CI flakiness. Also prevent renovate from updating pytest-asyncio as it breaks integration tests.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
