### PR TITLE
refactor: Use logger, not the root logger (logging)

### DIFF
--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -23,6 +23,8 @@ APP_NAME = METADATA["name"]
 SELF_SIGNED_CERTIFICATES_APPLICATION_NAME = "self-signed-certificates"
 VAULT_PKI_REQUIRER_APPLICATION_NAME = "tls-certificates-requirer"
 
+logger = logging.getLogger(__name__)
+
 
 def get_app(model: Model, app_name: str = APP_NAME) -> Application:
     """Get the application by name.
@@ -265,7 +267,7 @@ async def deploy_if_not_exists(
                 revision=revision,
             )
         except JujuError as e:
-            logging.warning(f"Failed to deploy the `{app_name}` charm: `%s`", e)
+            logger.warning(f"Failed to deploy the `{app_name}` charm: `%s`", e)
 
 
 async def get_juju_secret(model: Model, label: str, fields: List[str]) -> List[str]:

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -337,9 +337,9 @@ async def authorize_charm(
 
     assert isinstance(app := ops_test.model.applications[app_name], Application)
     if app.status == "active":
-        logging.info("The charm is already active, skipping authorization.")
+        logger.info("The charm is already active, skipping authorization.")
         return
-    logging.info(f"Authorizing the charm `{app_name}` to interact with Vault.")
+    logger.info(f"Authorizing the charm `{app_name}` to interact with Vault.")
     secret = await ops_test.model.add_secret(f"approle-token-{app_name}", [f"token={root_token}"])
     secret_id = secret.split(":")[-1]
     await ops_test.model.grant_secret(f"approle-token-{app_name}", app_name)
@@ -353,7 +353,7 @@ async def authorize_charm(
     result = await ops_test.model.get_action_output(
         action_uuid=authorize_action.entity_id, wait=120
     )
-    logging.info(f"Authorization result: {result}")
+    logger.info(f"Authorization result: {result}")
     return result
 
 


### PR DESCRIPTION
This is a bad habit I have that I blame on Django.

Unfortunately, the ruff check for this is still not stable.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
