### PR TITLE
refactor: Update libs and rename `outstanding_autounseal_requests` to `relations_without_credentials`

### DIFF
--- a/lib/charms/certificate_transfer_interface/v0/certificate_transfer.py
+++ b/lib/charms/certificate_transfer_interface/v0/certificate_transfer.py
@@ -101,6 +101,7 @@ import logging
 from typing import List, Mapping
 
 from jsonschema import exceptions, validate  # type: ignore[import-untyped]
+from ops import Relation
 from ops.charm import CharmBase, CharmEvents, RelationBrokenEvent, RelationChangedEvent
 from ops.framework import EventBase, EventSource, Handle, Object
 
@@ -112,7 +113,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 8
+LIBPATCH = 9
 
 PYDEPS = ["jsonschema"]
 
@@ -391,3 +392,11 @@ class CertificateTransferRequires(Object):
             None
         """
         self.on.certificate_removed.emit(relation_id=event.relation.id)
+
+    def is_ready(self, relation: Relation) -> bool:
+        """Check if the relation is ready by checking that it has valid relation data."""
+        relation_data = _load_relation_data(relation.data[relation.app])
+        if not self._relation_data_is_valid(relation_data):
+            logger.warning("Provider relation data did not pass JSON Schema validation: ")
+            return False
+        return True

--- a/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/lib/charms/grafana_agent/v0/cos_agent.py
@@ -22,7 +22,6 @@ this charm library.
 Using the `COSAgentProvider` object only requires instantiating it,
 typically in the `__init__` method of your charm (the one which sends telemetry).
 
-The constructor of `COSAgentProvider` has only one required and ten optional parameters:
 
 ```python
     def __init__(
@@ -253,7 +252,7 @@ if TYPE_CHECKING:
 
 LIBID = "dc15fa84cef84ce58155fb84f6c6213a"
 LIBAPI = 0
-LIBPATCH = 11
+LIBPATCH = 12
 
 PYDEPS = ["cosl", "pydantic"]
 

--- a/lib/charms/vault_k8s/v0/juju_facade.py
+++ b/lib/charms/vault_k8s/v0/juju_facade.py
@@ -9,6 +9,7 @@ from typing import List, Literal, cast
 from ops.charm import CharmBase
 from ops.model import (
     Application,
+    Binding,
     ModelError,
     Relation,
     RelationDataContent,
@@ -26,7 +27,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 4
 
 logger = logging.getLogger(__name__)
 
@@ -330,7 +331,7 @@ class JujuFacade:
         secret.grant(relation)
 
     # Relation related methods
-    def get_relation_by_id(self, relation_name: str, relation_id: int) -> Relation:
+    def get_relation(self, name: str, id: int) -> Relation:
         """Get the relation object by name and id.
 
         Returns:
@@ -339,10 +340,10 @@ class JujuFacade:
         Raises:
             NoSuchRelationError: if the relation does not exist
         """
-        relation = self.charm.model.get_relation(relation_name, relation_id)
+        relation = self.charm.model.get_relation(name, id)
         if not relation:
-            logger.error("Relation %s:%d not found", relation_name, relation_id)
-            raise NoSuchRelationError(f"Relation {relation_name}:{relation_id} not found")
+            logger.error("Relation %s:%d not found", name, id)
+            raise NoSuchRelationError(f"Relation {name}:{id} not found")
         return relation
 
     def get_relation_by_name(self, name: str) -> Relation:
@@ -361,44 +362,61 @@ class JujuFacade:
             raise MultipleRelationsFoundError(f"More than one relation found for name {name}")
         return relations[0]
 
-    def get_relations(self, relation_name: str, relation_id: int | None = None) -> List[Relation]:
+    def get_relations(self, name: str, id: int | None = None) -> List[Relation]:
         """Get all relation objects with the given name.
 
         Returns:
             A list of relation objects, the list is empty if no relations are found
         """
         relations = (
-            self.charm.model.relations.get(relation_name, [])
-            if not relation_id
-            else [self.get_relation_by_id(relation_name, relation_id)]
+            self.charm.model.relations.get(name, []) if not id else [self.get_relation(name, id)]
         )
+        if not relations:
+            logger.warning("No relations found for %s", name)
         return relations
 
-    def get_active_relations(
-        self, relation_name: str, relation_id: int | None = None
-    ) -> List[Relation]:
+    def get_active_relation(self, name: str, id: int) -> Relation | None:
+        """Get the active relation object by name and id."""
+        relation = self.get_relation(name, id)
+        if not relation.active:
+            logger.warning("Relation %s:%d is not active", name, id)
+            return None
+        return relation
+
+    def get_active_relations(self, name: str, id: int | None = None) -> List[Relation]:
         """Get all relations with the given name or ID that are active."""
-        relations = self.get_relations(relation_name, relation_id)
+        relations = self.get_relations(name, id)
         return [relation for relation in relations if relation.active]
 
-    def relation_exists(self, relation_name: str) -> bool:
+    def relation_exists(self, name: str) -> bool:
         """Check if there are any relations with the given name."""
-        return self.get_relations(relation_name) != []
+        return self.get_relations(name) != []
 
     def _read_relation_data(
-        self, relation_name: str, relation_id: int | None, entity: Unit | Application
+        self,
+        name: str,
+        entity: Unit | Application,
+        id: int | None,
+        relation: Relation | None = None,
     ) -> RelationDataContent | dict[str, str]:
+        if not relation and not id:
+            raise ValueError("Either relation or relation_id must be provided")
         relation = (
-            self.get_relation_by_id(relation_name, relation_id)
-            if relation_id
-            else self.get_relation_by_name(relation_name)
+            (self.get_relation(name, id) if id else self.get_relation_by_name(name))
+            if not relation
+            else relation
         )
         return relation.data.get(entity, {})
 
     def get_app_relation_data(
-        self, relation_name: str, relation_id: int | None
+        self,
+        name: str,
+        id: int | None = None,
+        relation: Relation | None = None,
     ) -> RelationDataContent | dict[str, str]:
         """Get relation data from the caller's application databag.
+
+        Either relation or relation_id must be provided.
 
         Returns:
             The relation data as a dict
@@ -407,12 +425,22 @@ class JujuFacade:
             NoSuchRelationError
             MultipleRelationsFoundError
         """
-        return self._read_relation_data(relation_name, relation_id, self.charm.model.app)
+        return self._read_relation_data(
+            name=name,
+            entity=self.charm.model.app,
+            id=id,
+            relation=relation,
+        )
 
     def get_remote_app_relation_data(
-        self, relation_name: str, relation_id: int | None = None
+        self,
+        name: str,
+        id: int | None = None,
+        relation: Relation | None = None,
     ) -> RelationDataContent | dict[str, str]:
         """Get relation data from the remote application databag.
+
+        Either relation or relation_id must be provided.
 
         Returns:
             The relation data as a dict
@@ -422,71 +450,108 @@ class JujuFacade:
             MultipleRelationsFoundError
         """
         relation = (
-            self.get_relation_by_id(relation_name, relation_id)
-            if relation_id
-            else self.get_relation_by_name(relation_name)
+            (self.get_relation(name, id) if id else self.get_relation_by_name(name))
+            if not relation
+            else relation
         )
         if not relation:
-            raise NoSuchRelationError(f"Relation {relation_name}:{relation_id} not found")
+            raise NoSuchRelationError(f"Relation {name}:{id} not found")
         if not relation.app:
             logger.warning("No remote application yet")
-            raise NoRemoteAppError(
-                f"Relation {relation_name}:{relation_id} has no remote application yet"
-            )
+            raise NoRemoteAppError(f"Relation {name}:{id} has no remote application yet")
         return relation.data.get(relation.app, {})
 
     def get_unit_relation_data(
-        self, relation_name: str, relation_id: int | None
+        self,
+        name: str,
+        id: int | None = None,
+        relation: Relation | None = None,
     ) -> RelationDataContent | dict[str, str]:
-        """Get relation data from the remote unit databag.
+        """Get relation data from the caller's unit databag.
 
         Raises:
             NoSuchRelationError
             MultipleRelationsFoundError
         """
-        return self._read_relation_data(relation_name, relation_id, self.charm.model.unit)
+        return self._read_relation_data(
+            name=name,
+            entity=self.charm.model.unit,
+            id=id,
+            relation=relation,
+        )
+
+    def get_remote_unit_relation_data(
+        self,
+        name: str,
+        unit: Unit,
+        id: int | None = None,
+        relation: Relation | None = None,
+    ) -> RelationDataContent | dict[str, str]:
+        """Get relation data from the remote unit databag."""
+        return self._read_relation_data(
+            name=name,
+            entity=unit,
+            id=id,
+            relation=relation,
+        )
 
     def get_remote_units_relation_data(
-        self, relation_name: str, relation_id: int | None
+        self,
+        name: str,
+        id: int | None = None,
+        relation: Relation | None = None,
     ) -> List[RelationDataContent | dict[str, str]]:
         """Get relation data from the remote units databags.
 
         Raises:
             NoSuchRelationError
             MultipleRelationsFoundError
+            ValueError
         """
+        if not relation and not id:
+            raise ValueError("Either relation or relation_id must be provided")
         relation = (
-            self.get_relation_by_id(relation_name, relation_id)
-            if relation_id
-            else self.get_relation_by_name(relation_name)
+            (self.get_relation(name, id) if id else self.get_relation_by_name(name))
+            if not relation
+            else relation
         )
         return [relation.data.get(unit, {}) for unit in relation.units]
 
     def _set_relation_data(
         self,
         data: dict[str, str],
-        relation_name: str,
-        relation_id: int | None,
+        name: str,
         entity: Unit | Application,
+        id: int | None = None,
+        relation: Relation | None = None,
     ) -> None:
+        if not relation and not id:
+            raise ValueError("Either relation or relation_id must be provided")
         relation = (
-            self.get_relation_by_id(relation_name, relation_id)
-            if relation_id
-            else self.get_relation_by_name(relation_name)
+            (self.get_relation(name, id) if id else self.get_relation_by_name(name))
+            if not relation
+            else relation
         )
         if not all(isinstance(value, str) for value in chain(data.values(), data.keys())):
             raise InvalidRelationDataError("Invalid relation data")
         try:
-            logger.info("Setting relation data for %s:%d", relation_name, relation_id)
+            logger.info("Setting relation data for %s:%d", name, id or relation.id)
             relation.data[entity].update(data)
         except RelationDataError as e:
             logger.error(
-                "Error setting relation data for %s:%d: %s", relation_name, relation_id, e
+                "Error setting relation data for %s:%d: %s",
+                name,
+                id or relation.id,
+                e,
             )
             raise InvalidRelationDataError(e) from e
 
     def set_app_relation_data(
-        self, data: dict[str, str], relation_name: str, relation_id: int | None
+        self,
+        data: dict[str, str],
+        name: str,
+        id: int | None = None,
+        relation: Relation | None = None,
     ) -> None:
         """Set relation data in the caller's application databag.
 
@@ -500,13 +565,18 @@ class JujuFacade:
             raise NotLeaderError("Action not allowed for non-leader units")
         self._set_relation_data(
             data=data,
-            relation_name=relation_name,
-            relation_id=relation_id,
+            name=name,
+            id=id,
+            relation=relation,
             entity=self.charm.model.app,
         )
 
     def set_unit_relation_data(
-        self, data: dict[str, str], relation_name: str, relation_id: int | None
+        self,
+        data: dict[str, str],
+        name: str,
+        id: int | None = None,
+        relation: Relation | None = None,
     ) -> None:
         """Set relation data in the caller's unit databag.
 
@@ -517,8 +587,9 @@ class JujuFacade:
         """
         self._set_relation_data(
             data=data,
-            relation_name=relation_name,
-            relation_id=relation_id,
+            name=name,
+            id=id,
+            relation=relation,
             entity=self.charm.model.unit,
         )
 
@@ -542,6 +613,47 @@ class JujuFacade:
         if not storages[storage_name]:
             raise NoSuchStorageError(f"Storage {storage_name} not found")
         return storages[storage_name][0].location
+
+    def get_binding(
+        self,
+        relation_name: str,
+        relation: Relation | None = None,
+        relation_id: int | None = None,
+    ) -> Binding | None:
+        """Get the binding for the given relation."""
+        if not relation and not relation_id:
+            raise ValueError("Either relation or relation_id must be provided")
+        relation = (
+            (
+                self.get_relation(relation_name, relation_id)
+                if relation_id
+                else self.get_relation_by_name(relation_name)
+            )
+            if not relation
+            else relation
+        )
+        return self.charm.model.get_binding(relation)
+
+    def get_egress_subnets(
+        self,
+        relation_name: str,
+        relation_id: int | None = None,
+        relation: Relation | None = None,
+    ) -> List[str]:
+        """Get the list of egress subnets for the given relation.
+
+        This returns how units on the relation will see the charm connecting from.
+        For example ['10.0.0.1/32', '10.1.1.1/32']
+        """
+        binding = self.get_binding(
+            relation_name=relation_name, relation_id=relation_id, relation=relation
+        )
+        if not binding:
+            return []
+        egress_subnets = [str(subnet) for subnet in binding.network.egress_subnets]
+        if binding.network.interfaces:
+            egress_subnets.append(str(binding.network.interfaces[0].subnet))
+        return egress_subnets
 
     @property
     def model_name(self) -> str:

--- a/lib/charms/vault_k8s/v0/vault_autounseal.py
+++ b/lib/charms/vault_k8s/v0/vault_autounseal.py
@@ -64,7 +64,7 @@ where `vault a` is the Vault app which will provide the autounseal service, and
 
 import logging
 from dataclasses import dataclass
-from typing import Any, Dict, List
+from typing import Any, Dict, List, MutableMapping
 
 from charms.vault_k8s.v0.juju_facade import (
     JujuFacade,
@@ -99,7 +99,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 6
 
 
 AUTOUNSEAL_CREDENTIALS_SECRET_LABEL_PREFIX = "vault-autounseal-credentials-"
@@ -110,7 +110,7 @@ class LogAdapter(logging.LoggerAdapter):
 
     prefix = "vault_autounseal"
 
-    def process(self, msg, kwargs):
+    def process(self, msg: str, kwargs: MutableMapping) -> tuple[str, MutableMapping]:
         """Prepend the prefix to the log message."""
         return f"[{self.prefix}] {msg}", kwargs
 
@@ -146,7 +146,14 @@ class VaultAutounsealDetailsReadyEvent(EventBase):
     """Event emitted on the requirer when Vault autounseal details are ready in the databag."""
 
     def __init__(
-        self, handle: Handle, address, mount_path, key_name, role_id, secret_id, ca_certificate
+        self,
+        handle: Handle,
+        address: str,
+        mount_path: str,
+        key_name: str,
+        role_id: str,
+        secret_id: str,
+        ca_certificate: str,
     ):
         """VaultAutounsealDetailsReadyEvent.
 
@@ -343,8 +350,8 @@ class VaultAutounsealProvides(Object):
         if secret.id is None:
             raise ValueError("Secret id is None")
         self.juju_facade.set_app_relation_data(
-            relation_name=self.relation_name,
-            relation_id=relation.id,
+            name=self.relation_name,
+            id=relation.id,
             data={
                 "address": vault_address,
                 "mount_path": mount_path,
@@ -354,22 +361,16 @@ class VaultAutounsealProvides(Object):
             },
         )
 
-    def get_outstanding_requests(self, relation_id: int | None = None) -> List[Relation]:
-        """Get the outstanding requests for the relation.
-
-        This will retrieve any vault-autounseal relations that have not yet had
-        credentials issued for them.
-        """
-        outstanding_requests: List[Relation] = []
-        requirer_requests = self.juju_facade.get_active_relations(self.relation_name, relation_id)
-        outstanding_requests = [
+    def get_relations_without_credentials(self, relation_id: int | None = None) -> List[Relation]:
+        """Get the relations which do not have credentials for auto-unseal."""
+        requirer_relations = self.juju_facade.get_active_relations(self.relation_name, relation_id)
+        return [
             relation
-            for relation in requirer_requests
-            if not self._credentials_issued_for_request(relation_id=relation.id)
+            for relation in requirer_relations
+            if not self._credentials_issued_for_relation(relation_id=relation.id)
         ]
-        return outstanding_requests
 
-    def _credentials_issued_for_request(self, relation_id: int) -> bool:
+    def _credentials_issued_for_relation(self, relation_id: int) -> bool:
         try:
             if not (
                 credentials_secret_id := self.juju_facade.get_app_relation_data(

--- a/src/charm.py
+++ b/src/charm.py
@@ -303,12 +303,14 @@ class VaultOperatorCharm(CharmBase):
             ca_cert=self.tls.pull_tls_file_from_workload(File.CA),
             mount_path=AUTOUNSEAL_MOUNT_PATH,
         )
-        outstanding_autounseal_requests = self.vault_autounseal_provides.get_outstanding_requests()
-        if outstanding_autounseal_requests:
+        relations_without_credentials = (
+            self.vault_autounseal_provides.get_relations_without_credentials()
+        )
+        if relations_without_credentials:
             vault_client.enable_secrets_engine(
                 SecretsBackend.TRANSIT, autounseal_provider_manager.mount_path
             )
-        for relation in outstanding_autounseal_requests:
+        for relation in relations_without_credentials:
             relation_address = self._get_relation_api_address(relation)
             if not relation_address:
                 logger.warning("Relation address not found for relation %s", relation.id)

--- a/tests/unit/fixtures.py
+++ b/tests/unit/fixtures.py
@@ -41,8 +41,8 @@ class VaultCharmFixtures:
     patcher_pki_requirer_renew_certificate = patch(
         "charm.TLSCertificatesRequiresV4.renew_certificate"
     )
-    patcher_autounseal_provides_get_outstanding_requests = patch(
-        "charm.VaultAutounsealProvides.get_outstanding_requests"
+    patcher_autounseal_provides_get_relations_without_credentials = patch(
+        "charm.VaultAutounsealProvides.get_relations_without_credentials"
     )
     patcher_autounseal_provides_set_data = patch(
         "charm.VaultAutounsealProvides.set_autounseal_data"
@@ -83,9 +83,7 @@ class VaultCharmFixtures:
         self.mock_pki_provider_set_relation_certificate = (
             VaultCharmFixtures.patcher_pki_provider_set_relation_certificate.start()
         )
-        self.mock_autounseal_provides_get_outstanding_requests = (
-            VaultCharmFixtures.patcher_autounseal_provides_get_outstanding_requests.start()
-        )
+        self.mock_autounseal_provides_get_relations_without_credentials = VaultCharmFixtures.patcher_autounseal_provides_get_relations_without_credentials.start()
         self.mock_autounseal_provides_set_data = (
             VaultCharmFixtures.patcher_autounseal_provides_set_data.start()
         )

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -26,7 +26,7 @@ from tests.unit.fixtures import VaultCharmFixtures
 class MockRelation:
     """Mock class for Relation used in Autounseal tests.
 
-    We shouldn't need this mock. If we replace the output return of `get_outstanding_requests`
+    We shouldn't need this mock. If we replace the output return of `get_relations_without_credentials`
     to be a list of relation ID's instead of a list of relation objects, we can remove this mock.
     """
 
@@ -37,7 +37,7 @@ class MockRelation:
 class MockNetwork:
     """Mock class for Relation used in Autounseal tests.
 
-    We shouldn't need this mock. If we replace the output return of `get_outstanding_requests`
+    We shouldn't need this mock. If we replace the output return of `get_relations_without_credentials`
     to be a list of relation ID's instead of a list of relation objects, we can remove this mock.
     """
 
@@ -49,7 +49,7 @@ class MockNetwork:
 class MockBinding:
     """Mock class for Relation used in Autounseal tests.
 
-    We shouldn't need this mock. If we replace the output return of `get_outstanding_requests`
+    We shouldn't need this mock. If we replace the output return of `get_relations_without_credentials`
     to be a list of relation ID's instead of a list of relation objects, we can remove this mock.
     """
 
@@ -408,7 +408,7 @@ class TestCharmConfigure(VaultCharmFixtures):
             ingress_address="myhostname",
         )
         relation = MockRelation(id=vault_autounseal_relation.id)
-        self.mock_autounseal_provides_get_outstanding_requests.return_value = [relation]
+        self.mock_autounseal_provides_get_relations_without_credentials.return_value = [relation]
         approle_secret = testing.Secret(
             label="vault-approle-auth-details",
             tracked_content={"role-id": "role id", "secret-id": "secret id"},
@@ -487,7 +487,7 @@ class TestCharmConfigure(VaultCharmFixtures):
             ingress_address="myhostname",
         )
         relation = MockRelation(id=vault_autounseal_relation.id)
-        self.mock_autounseal_provides_get_outstanding_requests.return_value = [relation]
+        self.mock_autounseal_provides_get_relations_without_credentials.return_value = [relation]
         approle_secret = testing.Secret(
             label="vault-approle-auth-details",
             tracked_content={"role-id": "role id", "secret-id": "secret id"},


### PR DESCRIPTION
Updates all the libs to the latest version (_except vault_kv, as there were some more significant changes in it_).

Also, renames `outstanding_autounseal_requests` to `relations_without_credentials`, to solve this:

https://github.com/canonical/vault-operator/pull/333#discussion_r1867994211

The same was done on the k8s charm: https://github.com/canonical/vault-k8s-operator/pull/550

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
