### PR TITLE
refactor: Remove PKI implementation, use manager

### DIFF
--- a/lib/charms/vault_k8s/v0/vault_client.py
+++ b/lib/charms/vault_k8s/v0/vault_client.py
@@ -13,7 +13,7 @@ from abc import abstractmethod
 from dataclasses import dataclass
 from enum import Enum
 from io import IOBase
-from typing import List, Protocol
+from typing import List, MutableMapping, Protocol
 
 import hvac
 import requests
@@ -28,7 +28,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 23
+LIBPATCH = 24
 
 
 RAFT_STATE_ENDPOINT = "v1/sys/storage/raft/autopilot/state"
@@ -39,7 +39,7 @@ class LogAdapter(logging.LoggerAdapter):
 
     prefix = "vault_client"
 
-    def process(self, msg, kwargs):
+    def process(self, msg: str, kwargs: MutableMapping) -> tuple[str, MutableMapping]:
         """Decides the format for the prepended text."""
         return f"[{self.prefix}] {msg}", kwargs
 
@@ -324,11 +324,11 @@ class VaultClient:
     def create_or_update_approle(
         self,
         name: str,
-        token_ttl=None,
-        token_max_ttl=None,
+        token_ttl: str | None = None,
+        token_max_ttl: str | None = None,
         policies: List[str] | None = None,
         cidrs: List[str] | None = None,
-        token_period=None,
+        token_period: str | None = None,
     ) -> str:
         """Create/update a role within vault associating the supplied policies.
 
@@ -464,7 +464,12 @@ class VaultClient:
                 "max_ttl": max_ttl,
             },
         )
-        logger.info("Created or updated PKI role %s", role)
+        logger.info(
+            "Created or updated PKI role `%s` with `allowed_domains=%s` and `max_ttl=%s`",
+            role,
+            allowed_domains,
+            max_ttl,
+        )
 
     def is_pki_role_created(self, role: str, mount: str) -> bool:
         """Check if the role is created for the PKI backend."""
@@ -547,28 +552,20 @@ class VaultClient:
             logger.warning("Role does not exist on the specified path.")
             return None
 
-    def make_latest_pki_issuer_default(self, mount: str) -> None:
-        """Update the issuers config to always make the latest issuer created default issuer."""
+    def list_pki_issuers(self, mount: str) -> List[str]:
+        """Get the list of issuers for the PKI backend.
+
+        Args:
+            mount: The mount point of the PKI backend.
+
+        Returns:
+            The list of issuers (i.e. ["issuer1", "issuer2"]).
+        """
         try:
-            first_issuer = self._client.secrets.pki.list_issuers(mount_point=mount)["data"][
-                "keys"
-            ][0]
+            return self._client.secrets.pki.list_issuers(mount_point=mount)["data"]["keys"]
         except (InvalidPath, KeyError) as e:
             logger.error("No issuers found on the specified path: %s", e)
             raise VaultClientError("No issuers found on the specified path.")
-        try:
-            issuers_config = self._client.read(path=f"{mount}/config/issuers")
-            if issuers_config and not issuers_config["data"]["default_follows_latest_issuer"]:  # type: ignore -- bad type hint in stubs
-                logger.debug("Updating issuers config")
-                self._client.write_data(
-                    path=f"{mount}/config/issuers",
-                    data={
-                        "default_follows_latest_issuer": True,
-                        "default": first_issuer,
-                    },
-                )
-        except (TypeError, KeyError):
-            logger.error("Issuers config is not yet created")
 
     def create_transit_key(self, mount_point: str, key_name: str) -> None:
         """Create a new key in the transit backend."""

--- a/lib/charms/vault_k8s/v0/vault_managers.py
+++ b/lib/charms/vault_k8s/v0/vault_managers.py
@@ -43,6 +43,10 @@ from charms.tls_certificates_interface.v4.tls_certificates import (
     Certificate,
     CertificateRequestAttributes,
     PrivateKey,
+    ProviderCertificate,
+    RequirerCertificateRequest,
+    TLSCertificatesError,
+    TLSCertificatesProvidesV4,
     TLSCertificatesRequiresV4,
     generate_ca,
     generate_certificate,
@@ -63,9 +67,12 @@ from charms.vault_k8s.v0.vault_autounseal import (
 )
 from charms.vault_k8s.v0.vault_client import (
     AppRole,
+    SecretsBackend,
     Token,
     VaultClient,
+    VaultClientError,
 )
+from charms.vault_k8s.v0.vault_kv import VaultKvProvides
 from ops import CharmBase, EventBase, Object, Relation
 from ops.pebble import PathError
 
@@ -77,11 +84,12 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 4
 
 
 SEND_CA_CERT_RELATION_NAME = "send-ca-cert"
 TLS_CERTIFICATE_ACCESS_RELATION_NAME = "tls-certificates-access"
+TLS_CERTIFICATES_PKI_RELATION_NAME = "tls-certificates-pki"
 CA_CERTIFICATE_JUJU_SECRET_LABEL = "self-signed-vault-ca-certificate"
 
 VAULT_CA_SUBJECT = "Vault self signed CA"
@@ -91,6 +99,15 @@ AUTOUNSEAL_POLICY = """path "{mount}/encrypt/{key_name}" {{
 
 path "{mount}/decrypt/{key_name}" {{
     capabilities = ["update"]
+}}
+"""
+
+KV_POLICY = """# Allows the KV requirer to create, read, update, delete and list secrets
+path "{mount}/*" {{
+  capabilities = ["create", "read", "update", "delete", "list"]
+}}
+path "sys/internal/ui/mounts/{mount}" {{
+  capabilities = ["read"]
 }}
 """
 
@@ -106,6 +123,12 @@ class LogAdapter(logging.LoggerAdapter):
 
 
 logger = LogAdapter(logging.getLogger(__name__), {})
+
+
+class ManagerError(Exception):
+    """Exception raised when a manager encounters an error."""
+
+    pass
 
 
 class TLSMode(Enum):
@@ -573,24 +596,49 @@ class Naming:
     provides a central place to manage them.
     """
 
-    key_prefix: str = ""
-    policy_prefix: str = "charm-autounseal-"
-    approle_prefix: str = "charm-autounseal-"
+    autounseal_approle_prefix: str = "charm-autounseal-"
+    autounseal_key_prefix: str = ""
+    autounseal_policy_prefix: str = "charm-autounseal-"
+    kv_mount_prefix: str = "charm-"
+    kv_secret_prefix: str = "vault-kv-"
 
     @classmethod
-    def key_name(cls, relation_id: int) -> str:
+    def autounseal_key_name(cls, relation_id: int) -> str:
         """Return the key name for the relation."""
-        return f"{cls.key_prefix}{relation_id}"
+        return f"{cls.autounseal_key_prefix}{relation_id}"
 
     @classmethod
-    def policy_name(cls, relation_id: int) -> str:
+    def autounseal_policy_name(cls, relation_id: int) -> str:
         """Return the policy name for the relation."""
-        return f"{cls.policy_prefix}{relation_id}"
+        return f"{cls.autounseal_policy_prefix}{relation_id}"
 
     @classmethod
-    def approle_name(cls, relation_id: int) -> str:
+    def autounseal_approle_name(cls, relation_id: int) -> str:
         """Return the approle name for the relation."""
-        return f"{cls.approle_prefix}{relation_id}"
+        return f"{cls.autounseal_approle_prefix}{relation_id}"
+
+    @classmethod
+    def kv_secret_label(cls, unit_name: str) -> str:
+        """Return the secret label for the KV backend."""
+        unit_name_dash = unit_name.replace("/", "-")
+        return f"{cls.kv_secret_prefix}{unit_name_dash}"
+
+    @classmethod
+    def kv_mount_path(cls, app_name: str, mount_suffix: str) -> str:
+        """Return the mount path for the KV backend."""
+        return f"{cls.kv_mount_prefix}{app_name}-{mount_suffix}"
+
+    @classmethod
+    def kv_policy_name(cls, mount_path: str, unit_name: str) -> str:
+        """Return the policy name for the KV backend."""
+        unit_name_dash = unit_name.replace("/", "-")
+        return f"{mount_path}-{unit_name_dash}"
+
+    @classmethod
+    def kv_role_name(cls, mount_path: str, unit_name: str) -> str:
+        """Return the role name for the KV backend."""
+        unit_name_dash = unit_name.replace("/", "-")
+        return f"{mount_path}-{unit_name_dash}"
 
 
 class AutounsealProviderManager:
@@ -649,7 +697,7 @@ class AutounsealProviderManager:
         """
         existing_keys = self._get_existing_keys()
         relation_key_names = [
-            Naming.key_name(relation.id)
+            Naming.autounseal_key_name(relation.id)
             for relation in self._juju_facade.get_active_relations(self._provides.relation_name)
         ]
         orphaned_keys = [key for key in existing_keys if key not in relation_key_names]
@@ -677,7 +725,7 @@ class AutounsealProviderManager:
         """Delete roles that are no longer associated with an autounseal Juju relation."""
         existing_roles = self._get_existing_roles()
         relation_role_names = [
-            Naming.approle_name(relation.id)
+            Naming.autounseal_approle_name(relation.id)
             for relation in self._juju_facade.get_active_relations(self._provides.relation_name)
         ]
         for role in existing_roles:
@@ -689,7 +737,7 @@ class AutounsealProviderManager:
         """Delete policies that are no longer associated with an autounseal Juju relation."""
         existing_policies = self._get_existing_policies()
         relation_policy_names = [
-            Naming.policy_name(relation.id)
+            Naming.autounseal_policy_name(relation.id)
             for relation in self._juju_facade.get_active_relations(self._provides.relation_name)
         ]
         for policy in existing_policies:
@@ -711,9 +759,9 @@ class AutounsealProviderManager:
         Returns:
             A tuple containing the key name, role ID, and approle secret ID.
         """
-        key_name = Naming.key_name(relation.id)
-        policy_name = Naming.policy_name(relation.id)
-        approle_name = Naming.approle_name(relation.id)
+        key_name = Naming.autounseal_key_name(relation.id)
+        policy_name = Naming.autounseal_policy_name(relation.id)
+        approle_name = Naming.autounseal_approle_name(relation.id)
         self._create_key(key_name)
         policy_content = AUTOUNSEAL_POLICY.format(mount=self.mount_path, key_name=key_name)
         self._client.create_or_update_policy(
@@ -742,11 +790,11 @@ class AutounsealProviderManager:
 
     def _get_existing_roles(self) -> list[str]:
         output = self._client.list("auth/approle/role")
-        return [role for role in output if role.startswith(Naming.approle_prefix)]
+        return [role for role in output if role.startswith(Naming.autounseal_approle_prefix)]
 
     def _get_existing_policies(self) -> list[str]:
         output = self._client.list("sys/policy")
-        return [policy for policy in output if policy.startswith(Naming.policy_prefix)]
+        return [policy for policy in output if policy.startswith(Naming.autounseal_policy_prefix)]
 
 
 @dataclass
@@ -816,3 +864,415 @@ class AutounsealRequirerManager:
                     label=self.AUTOUNSEAL_TOKEN_SECRET_LABEL,
                 )
         return external_vault.token
+
+
+class PKIManager:
+    """Encapsulates the business logic for managing PKI certificates in Vault from a Charm."""
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        vault_client: VaultClient,
+        certificate_request_attributes: CertificateRequestAttributes,
+        mount_point: str,
+        role_name: str,
+        vault_pki: TLSCertificatesProvidesV4,
+        tls_certificates_pki: TLSCertificatesRequiresV4,
+    ):
+        """Create a new PKIManager object.
+
+        Args:
+            charm: The charm this manager is associated with
+            vault_client: The Vault client object
+            certificate_request_attributes: The certificate request attributes
+                that were used when requesting an intermediate certificate from
+                the tls_certificates_pki relation provider.
+            mount_point: The mount point in Vault for the PKI backend
+            role_name: The role name for the PKI backend
+            vault_pki: The vault_pki provider relation helper library
+            tls_certificates_pki: The tls_certificates_pki requirer relation helper library
+        """
+        self._vault_client = vault_client
+        self._juju_facade = JujuFacade(charm)
+        self._mount_point = mount_point
+        self._role_name = role_name
+        self._vault_pki = vault_pki
+        self._tls_certificates_pki = tls_certificates_pki
+        self._certificate_request_attributes = certificate_request_attributes
+
+    def _get_pki_intermediate_ca_from_relation(
+        self,
+    ) -> tuple[ProviderCertificate | None, PrivateKey | None]:
+        """Get the intermediate CA certificate and private key from the relation data.
+
+        This is the CA certificate that the provider charm has issued to Vault.
+        """
+        provider_certificate, private_key = self._tls_certificates_pki.get_assigned_certificate(
+            certificate_request=self._certificate_request_attributes
+        )
+        if not provider_certificate:
+            logger.debug("No intermediate CA certificate available")
+        if not private_key:
+            logger.debug("No private key available")
+        return provider_certificate, private_key
+
+    def _get_vault_service_ca_certificate(self) -> Certificate | None:
+        """Get the current CA certificate from the Vault service."""
+        try:
+            intermediate_ca_cert = self._vault_client.get_intermediate_ca(mount=self._mount_point)
+            if not intermediate_ca_cert:
+                return None
+            return Certificate.from_string(intermediate_ca_cert)
+        except (VaultClientError, TLSCertificatesError) as e:
+            logger.error("Failed to get current CA certificate: %s", e)
+            return None
+
+    def _intermediate_ca_exceeds_role_ttl(self, intermediate_ca_certificate: Certificate) -> bool:
+        """Check if the intermediate CA's remaining validity exceeds the role's max TTL.
+
+        Vault PKI enforces that issued certificates cannot outlast their signing CA.
+        This method ensures that the intermediate CA's remaining validity period
+        is longer than the maximum TTL allowed for certificates issued by this role.
+        """
+        current_ttl = self._vault_client.get_role_max_ttl(
+            role=self._role_name, mount=self._mount_point
+        )
+        if (
+            not current_ttl
+            or not intermediate_ca_certificate.expiry_time
+            or not intermediate_ca_certificate.validity_start_time
+        ):
+            return False
+        certificate_validity = (
+            intermediate_ca_certificate.expiry_time
+            - intermediate_ca_certificate.validity_start_time
+        )
+        certificate_validity_seconds = certificate_validity.total_seconds()
+        return certificate_validity_seconds > current_ttl
+
+    def configure(self):
+        """Enable the PKI backend and update the PKI role in Vault.
+
+        This method retrieves the intermediate certificate from the relation
+        and configures the PKI role in Vault if they have changed (or haven't
+        yet been configured). It will also revoke all existing certificates if
+        the provider has issued a new CA certificate, and ensure all future
+        certificates are issued by the new CA certificate.
+
+        Additionally, this method ensures that the intermediate CA certificate
+        is renewed if necessary.
+        """
+        if not self._juju_facade.is_leader:
+            logger.debug("Only leader unit can handle a vault-pki certificate requests")
+            return
+        if not self._juju_facade.relation_exists(TLS_CERTIFICATES_PKI_RELATION_NAME):
+            logger.debug("No PKI relation exists: `%s`", TLS_CERTIFICATES_PKI_RELATION_NAME)
+            return
+        self._vault_client.enable_secrets_engine(SecretsBackend.PKI, self._mount_point)
+        logger.info("Enabled PKI secrets engine at %s", self._mount_point)
+
+        certificate_from_provider, private_key = self._get_pki_intermediate_ca_from_relation()
+        if not certificate_from_provider or not private_key:
+            return
+        vault_service_ca_certificate = self._get_vault_service_ca_certificate()
+        if (
+            vault_service_ca_certificate
+            and vault_service_ca_certificate == certificate_from_provider.certificate
+        ):
+            if not self._intermediate_ca_exceeds_role_ttl(vault_service_ca_certificate):
+                self._tls_certificates_pki.renew_certificate(
+                    certificate_from_provider,
+                )
+                logger.debug("Renewing CA certificate")
+                return
+            logger.debug("CA certificate already set in the PKI secrets engine")
+            return
+        self._vault_pki.revoke_all_certificates()
+        self._vault_client.import_ca_certificate_and_key(
+            certificate=str(certificate_from_provider.certificate),
+            private_key=str(private_key),
+            mount=self._mount_point,
+        )
+        issued_certificates_validity = PKIManager.calculate_pki_certificates_ttl(
+            certificate_from_provider.certificate
+        )
+        if not self._vault_client.is_common_name_allowed_in_pki_role(
+            role=self._role_name,
+            mount=self._mount_point,
+            common_name=self._certificate_request_attributes.common_name,
+        ) or issued_certificates_validity != self._vault_client.get_role_max_ttl(
+            role=self._role_name, mount=self._mount_point
+        ):
+            self._vault_client.create_or_update_pki_charm_role(
+                allowed_domains=self._certificate_request_attributes.common_name,
+                mount=self._mount_point,
+                role=self._role_name,
+                max_ttl=f"{issued_certificates_validity}s",
+            )
+        self.make_latest_pki_issuer_default()
+
+    def make_latest_pki_issuer_default(self):
+        """Make the latest PKI issuer the default issuer.
+
+        This ensures that the latest issuer we have created is used for signing
+        certificates.
+        """
+        try:
+            first_issuer = self._vault_client.list_pki_issuers(mount=self._mount_point)[0]
+        except (VaultClientError, IndexError) as e:
+            logger.error("Failed to get the first issuer: %s", e)
+            return
+        try:
+            issuers_config = self._vault_client.read(path=f"{self._mount_point}/config/issuers")
+            if issuers_config and not issuers_config["default_follows_latest_issuer"]:
+                logger.debug("Updating issuers config")
+                self._vault_client.write(
+                    path=f"{self._mount_point}/config/issuers",
+                    data={
+                        "default_follows_latest_issuer": True,
+                        "default": first_issuer,
+                    },
+                )
+        except (TypeError, KeyError):
+            logger.error("Issuers config is not yet created")
+
+    def sync(self):
+        """Sync the state of the PKI backend with the TLS certificates relations.
+
+        Issues certificates for all outstanding requests.
+        """
+        if not self._juju_facade.is_leader:
+            logger.debug("Only leader unit can handle a vault-pki request")
+            return
+        if not self._juju_facade.relation_exists(TLS_CERTIFICATES_PKI_RELATION_NAME):
+            logger.debug("TLS Certificates PKI relation not created")
+            return
+        outstanding_pki_requests = self._vault_pki.get_outstanding_certificate_requests()
+        for pki_request in outstanding_pki_requests:
+            self._generate_pki_certificate_for_requirer(
+                requirer_csr=pki_request,
+            )
+
+    def _generate_pki_certificate_for_requirer(self, requirer_csr: RequirerCertificateRequest):
+        if not self._vault_client.is_pki_role_created(
+            role=self._role_name, mount=self._mount_point
+        ):
+            logger.debug("PKI role not created")
+            return
+        provider_certificate, _ = self._get_pki_intermediate_ca_from_relation()
+        if not provider_certificate:
+            return
+        allowed_cert_validity = PKIManager.calculate_pki_certificates_ttl(
+            provider_certificate.certificate
+        )
+        certificate = self._vault_client.sign_pki_certificate_signing_request(
+            mount=self._mount_point,
+            role=self._role_name,
+            csr=str(requirer_csr.certificate_signing_request),
+            common_name=requirer_csr.certificate_signing_request.common_name,
+            ttl=f"{allowed_cert_validity}s",
+        )
+        if not certificate:
+            logger.debug("Failed to sign the certificate")
+            return
+        provider_certificate = ProviderCertificate(
+            relation_id=requirer_csr.relation_id,
+            certificate=Certificate.from_string(certificate.certificate),
+            certificate_signing_request=requirer_csr.certificate_signing_request,
+            ca=Certificate.from_string(certificate.ca),
+            chain=[Certificate.from_string(cert) for cert in certificate.chain],
+        )
+        self._vault_pki.set_relation_certificate(
+            provider_certificate=provider_certificate,
+        )
+
+    @staticmethod
+    def calculate_pki_certificates_ttl(certificate: Certificate) -> int:
+        """Calculate the maximum allowed validity of certificates issued by PKI.
+
+        The current implementation returns half the validity of the CA certificate.
+        """
+        if not certificate.expiry_time or not certificate.validity_start_time:
+            raise ValueError("Invalid CA certificate with no expiry time or validity start time")
+        ca_validity_time = certificate.expiry_time - certificate.validity_start_time
+        ca_validity_seconds = ca_validity_time.total_seconds()
+        return int(ca_validity_seconds / 2)
+
+
+class KVManager:
+    """Encapsulates the business logic for managing KV credentials for requirer Charms."""
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        vault_client: VaultClient,
+        vault_kv: VaultKvProvides,
+        ca_cert: str,
+    ):
+        self._vault_client = vault_client
+        self._juju_facade = JujuFacade(charm)
+        self._vault_kv = vault_kv
+        self._ca_cert = ca_cert
+
+    def generate_credentials_for_requirer(
+        self,
+        relation: Relation,
+        app_name: str,
+        unit_name: str,
+        mount_suffix: str,
+        egress_subnets: list[str],
+        nonce: str,
+        vault_url: str,
+    ):
+        """Generate KV credentials for the requirer, and store the credentials in the relation.
+
+        This method ensures that the approle and policy are created or updated,
+        and that the approle secret ID is generated and stored in a Juju secret.
+
+        The Juju secret ID is then passed to the requirer, along with other
+        necessary information to access the KV backend.
+
+        Args:
+            relation: The relation of the requirer
+            app_name: The name of the requirer application
+            unit_name: The name of the requirer unit for this relation
+            mount_suffix: The suffix to append to the mount path, as provided by the requirer
+            egress_subnets: The egress subnets of the requirer
+            nonce: The nonce provided by the requirer
+            vault_url: The URL of the Vault server that the requirer can access
+                over this relation.
+        """
+        if not self._juju_facade.is_leader:
+            logger.debug("Only leader unit can handle a vault-kv request")
+            return
+        mount = Naming.kv_mount_path(app_name, mount_suffix)
+        self._vault_client.enable_secrets_engine(SecretsBackend.KV_V2, mount)
+        secret_id = self._ensure_unit_credentials(
+            relation=relation,
+            unit_name=unit_name,
+            mount=mount,
+            nonce=nonce,
+            egress_subnets=egress_subnets,
+        )
+        self._vault_kv.set_kv_data(
+            relation=relation,
+            mount=mount,
+            ca_certificate=self._ca_cert,
+            vault_url=vault_url,
+            nonce=nonce,
+            credentials_juju_secret_id=secret_id,
+        )
+        self._remove_stale_nonce(relation=relation, nonce=nonce)
+
+    def _remove_stale_nonce(self, relation: Relation, nonce: str) -> None:
+        """Remove stale nonce.
+
+        If the nonce is not present in the credentials, it is stale and should be removed.
+
+        Args:
+            relation: the reltaion from which to check the credentials for the nonce
+            nonce: the one to remove if stale
+        """
+        credential_nonces = self._vault_kv.get_credentials(relation).keys()
+        if nonce not in set(credential_nonces):
+            self._vault_kv.remove_unit_credentials(relation, nonce=nonce)
+
+    def _ensure_unit_credentials(
+        self,
+        relation: Relation,
+        unit_name: str,
+        mount: str,
+        nonce: str,
+        egress_subnets: list[str],
+    ) -> str:
+        """Ensure a unit has credentials to access the vault-kv mount.
+
+        If the credentials are already configured for the provided egress
+        subnets, the existing Juju secret ID which contains the approle secret
+        ID is returned.
+
+        Otherwise, the necessary Vault policy and approle are created or
+        updated as necessary.  A Vault secret ID is then generated for the
+        approle and stored in a Juju secret. The secret is granted to the
+        associate relation, and the ID of the Juju secret is returned.
+
+        Returns:
+            The ID of the Juju secret containing the approle secret ID.
+        """
+        policy_name = Naming.kv_policy_name(mount, unit_name)
+        role_name = Naming.kv_role_name(mount, unit_name)
+
+        juju_secret_label = Naming.kv_secret_label(unit_name=unit_name)
+        current_credentials = self._vault_kv.get_credentials(relation)
+        credentials_juju_secret_id = current_credentials.get(nonce, None)
+
+        if self._is_vault_kv_role_configured(
+            label=juju_secret_label,
+            egress_subnets=egress_subnets,
+            role_name=role_name,
+            credentials_juju_secret_id=credentials_juju_secret_id,
+        ):
+            logger.info("Vault KV role already configured for the provided egress subnets")
+            return credentials_juju_secret_id
+        self._vault_client.create_or_update_policy(policy_name, KV_POLICY.format(mount=mount))
+        role_id = self._vault_client.create_or_update_approle(
+            role_name,
+            policies=[policy_name],
+            cidrs=egress_subnets,
+            token_ttl="1h",
+            token_max_ttl="1h",
+        )
+        role_secret_id = self._vault_client.generate_role_secret_id(role_name, egress_subnets)
+        secret = self._juju_facade.set_app_secret_content(
+            content={"role-id": role_id, "role-secret-id": role_secret_id},
+            label=juju_secret_label,
+        )
+        self._juju_facade.grant_secret(relation, secret=secret)
+        if not secret.id:
+            raise ValueError(
+                f"Unexpected error, just created secret {juju_secret_label!r} has no id"
+            )
+        return secret.id
+
+    def _is_vault_kv_role_configured(
+        self,
+        label: str,
+        egress_subnets: list[str],
+        role_name: str,
+        credentials_juju_secret_id: str,
+    ) -> bool:
+        """Check if the Vault role is already configured for the provided egress subnets.
+
+        Args:
+            label: The label of the secret
+            egress_subnets: The egress subnets provided by the requirer.
+            role_name: The role name associated with KV for this unit.
+            credentials_juju_secret_id: The juju secret id.
+
+        Returns:
+            True if the role is already configured with the provided egress
+        subnets, False otherwise.
+        """
+        try:
+            role_secret_id = self._juju_facade.get_latest_secret_content(
+                label=label,
+                id=credentials_juju_secret_id,
+            ).get("role-secret-id")
+        except NoSuchSecretError:
+            return False
+        if not role_secret_id:
+            return False
+        role_data = self._vault_client.read_role_secret(role_name, role_secret_id)
+        if egress_subnets == role_data["cidr_list"]:
+            return True
+        return False
+
+    @staticmethod
+    def remove_unit_credentials(juju_facade: JujuFacade, unit_name: str) -> None:
+        """Remove any KV credentials associated with the given unit.
+
+        Args:
+            juju_facade: The JujuFacade object to use for removing the secret
+            unit_name: The name of the unit for which to remove the secret
+        """
+        juju_facade.remove_secret(Naming.kv_secret_label(unit_name=unit_name))

--- a/tests/unit/fixtures.py
+++ b/tests/unit/fixtures.py
@@ -10,6 +10,7 @@ from charms.vault_k8s.v0.vault_client import VaultClient
 from charms.vault_k8s.v0.vault_managers import (
     AutounsealProviderManager,
     AutounsealRequirerManager,
+    PKIManager,
     TLSManager,
 )
 from charms.vault_k8s.v0.vault_s3 import S3
@@ -26,6 +27,7 @@ class VaultCharmFixtures:
     patcher_vault_autounseal_requirer_manager = patch(
         "charm.AutounsealRequirerManager", autospec=AutounsealRequirerManager
     )
+    patcher_pki_manager = patch("charm.PKIManager", autospec=PKIManager)
     patcher_s3_requirer = patch("charm.S3Requirer", autospec=S3Requirer)
     patcher_s3 = patch("charm.S3", autospec=S3)
     patcher_socket_fqdn = patch("socket.getfqdn")
@@ -60,6 +62,7 @@ class VaultCharmFixtures:
         self.mock_vault_autounseal_manager = (
             VaultCharmFixtures.patcher_vault_autounseal_provider_manager.start().return_value
         )
+        self.mock_pki_manager = VaultCharmFixtures.patcher_pki_manager.start().return_value
         self.mock_vault_autounseal_requirer_manager = (
             VaultCharmFixtures.patcher_vault_autounseal_requirer_manager.start().return_value
         )


### PR DESCRIPTION
Removes the machine charm implementation of PKI support and uses the manager instead.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
