### PR TITLE
refactor: Remove KV implementation and use manager instead

### DIFF
--- a/src/templates/kv_mount.hcl
+++ b/src/templates/kv_mount.hcl
@@ -1,6 +1,0 @@
-path "{mount}/*" {{
-  capabilities = ["create", "read", "update", "delete", "list"]
-}}
-path "sys/internal/ui/mounts/{mount}" {{
-  capabilities = ["read"]
-}}

--- a/tests/unit/fixtures.py
+++ b/tests/unit/fixtures.py
@@ -10,6 +10,7 @@ from charms.vault_k8s.v0.vault_client import VaultClient
 from charms.vault_k8s.v0.vault_managers import (
     AutounsealProviderManager,
     AutounsealRequirerManager,
+    KVManager,
     PKIManager,
     TLSManager,
 )
@@ -27,6 +28,7 @@ class VaultCharmFixtures:
     patcher_vault_autounseal_requirer_manager = patch(
         "charm.AutounsealRequirerManager", autospec=AutounsealRequirerManager
     )
+    patcher_kv_manager = patch("charm.KVManager", autospec=KVManager)
     patcher_pki_manager = patch("charm.PKIManager", autospec=PKIManager)
     patcher_s3_requirer = patch("charm.S3Requirer", autospec=S3Requirer)
     patcher_s3 = patch("charm.S3", autospec=S3)
@@ -66,6 +68,7 @@ class VaultCharmFixtures:
         self.mock_vault_autounseal_requirer_manager = (
             VaultCharmFixtures.patcher_vault_autounseal_requirer_manager.start().return_value
         )
+        self.mock_kv_manager = VaultCharmFixtures.patcher_kv_manager.start().return_value
         self.mock_s3_requirer = VaultCharmFixtures.patcher_s3_requirer.start().return_value
         self.mock_s3 = VaultCharmFixtures.patcher_s3.start()
         self.mock_socket_fqdn = VaultCharmFixtures.patcher_socket_fqdn.start()


### PR DESCRIPTION
~~Needs #347~~

Removes the machine charm implementation of KV and uses the manager implemented in https://github.com/canonical/vault-k8s-operator/pull/571 instead.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
