### PR TITLE
fix: Use locked dependencies when running tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,8 @@ integration_test_path = {toxinidir}/tests/integration/
 all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]integration_test_path}
 
 [testenv]
+runner = uv-venv-lock-runner
+with_dev = true
 set_env =
     PYTHONPATH = {toxinidir}:{tox_root}/lib:{[vars]src_path}
     PYTHONBREAKPOINT=pdb.set_trace


### PR DESCRIPTION
# Description

This forces tox to use the locked dependencies with uv.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
