### PR TITLE
refactor: Use contextmanagers instead of patchers

### DIFF
--- a/tests/unit/fixtures.py
+++ b/tests/unit/fixtures.py
@@ -1,6 +1,7 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+from contextlib import ExitStack
 from unittest.mock import patch
 
 import ops.testing as testing
@@ -14,91 +15,68 @@ from charms.vault_k8s.v0.vault_managers import (
     PKIManager,
     TLSManager,
 )
-from charms.vault_k8s.v0.vault_s3 import S3
 
 from charm import VaultOperatorCharm
 
 
 class VaultCharmFixtures:
-    patcher_tls = patch("charm.TLSManager", autospec=TLSManager)
-    patcher_vault = patch("charm.VaultClient", autospec=VaultClient)
-    patcher_vault_autounseal_provider_manager = patch(
-        "charm.AutounsealProviderManager", autospec=AutounsealProviderManager
-    )
-    patcher_vault_autounseal_requirer_manager = patch(
-        "charm.AutounsealRequirerManager", autospec=AutounsealRequirerManager
-    )
-    patcher_kv_manager = patch("charm.KVManager", autospec=KVManager)
-    patcher_pki_manager = patch("charm.PKIManager", autospec=PKIManager)
-    patcher_s3_requirer = patch("charm.S3Requirer", autospec=S3Requirer)
-    patcher_s3 = patch("charm.S3", autospec=S3)
-    patcher_socket_fqdn = patch("socket.getfqdn")
-    patcher_pki_requirer_get_assigned_certificate = patch(
-        "charm.TLSCertificatesRequiresV4.get_assigned_certificate"
-    )
-    patcher_pki_provider_get_outstanding_certificate_requests = patch(
-        "charm.TLSCertificatesProvidesV4.get_outstanding_certificate_requests"
-    )
-    patcher_pki_provider_set_relation_certificate = patch(
-        "charm.TLSCertificatesProvidesV4.set_relation_certificate"
-    )
-    patcher_pki_requirer_renew_certificate = patch(
-        "charm.TLSCertificatesRequiresV4.renew_certificate"
-    )
-    patcher_autounseal_provides_get_relations_without_credentials = patch(
-        "charm.VaultAutounsealProvides.get_relations_without_credentials"
-    )
-    patcher_autounseal_provides_set_data = patch(
-        "charm.VaultAutounsealProvides.set_autounseal_data"
-    )
-    patcher_autounseal_requires_get_details = patch("charm.VaultAutounsealRequires.get_details")
-    patcher_kv_provides_set_kv_data = patch("charm.VaultKvProvides.set_kv_data")
-    patcher_kv_provides_get_credentials = patch("charm.VaultKvProvides.get_credentials")
-    patcher_snap_cache = patch("charm.snap.SnapCache")
-    patcher_machine = patch("charm.Machine")
-
     @pytest.fixture(autouse=True)
     def setup(self):
-        self.mock_tls = VaultCharmFixtures.patcher_tls.start().return_value
-        self.mock_vault = VaultCharmFixtures.patcher_vault.start().return_value
-        self.mock_vault_autounseal_manager = (
-            VaultCharmFixtures.patcher_vault_autounseal_provider_manager.start().return_value
-        )
-        self.mock_pki_manager = VaultCharmFixtures.patcher_pki_manager.start().return_value
-        self.mock_vault_autounseal_requirer_manager = (
-            VaultCharmFixtures.patcher_vault_autounseal_requirer_manager.start().return_value
-        )
-        self.mock_kv_manager = VaultCharmFixtures.patcher_kv_manager.start().return_value
-        self.mock_s3_requirer = VaultCharmFixtures.patcher_s3_requirer.start().return_value
-        self.mock_s3 = VaultCharmFixtures.patcher_s3.start()
-        self.mock_socket_fqdn = VaultCharmFixtures.patcher_socket_fqdn.start()
-        self.mock_pki_requirer_get_assigned_certificate = (
-            VaultCharmFixtures.patcher_pki_requirer_get_assigned_certificate.start()
-        )
-        self.mock_pki_requirer_renew_certificate = (
-            VaultCharmFixtures.patcher_pki_requirer_renew_certificate.start()
-        )
-        self.mock_pki_provider_get_outstanding_certificate_requests = (
-            VaultCharmFixtures.patcher_pki_provider_get_outstanding_certificate_requests.start()
-        )
-        self.mock_pki_provider_set_relation_certificate = (
-            VaultCharmFixtures.patcher_pki_provider_set_relation_certificate.start()
-        )
-        self.mock_autounseal_provides_get_relations_without_credentials = VaultCharmFixtures.patcher_autounseal_provides_get_relations_without_credentials.start()
-        self.mock_autounseal_provides_set_data = (
-            VaultCharmFixtures.patcher_autounseal_provides_set_data.start()
-        )
-        self.mock_autounseal_requires_get_details = (
-            VaultCharmFixtures.patcher_autounseal_requires_get_details.start()
-        )
-        self.mock_kv_provides_set_kv_data = (
-            VaultCharmFixtures.patcher_kv_provides_set_kv_data.start()
-        )
-        self.mock_kv_provides_get_credentials = (
-            VaultCharmFixtures.patcher_kv_provides_get_credentials.start()
-        )
-        self.mock_snap_cache = VaultCharmFixtures.patcher_snap_cache.start()
-        self.mock_machine = VaultCharmFixtures.patcher_machine.start().return_value
+        with ExitStack() as stack:
+            self.mock_tls = stack.enter_context(
+                patch("charm.TLSManager", autospec=TLSManager)
+            ).return_value
+            self.mock_vault = stack.enter_context(
+                patch("charm.VaultClient", autospec=VaultClient)
+            ).return_value
+            self.mock_vault_autounseal_provider_manager = stack.enter_context(
+                patch("charm.AutounsealProviderManager", autospec=AutounsealProviderManager)
+            ).return_value
+            self.mock_vault_autounseal_requirer_manager = stack.enter_context(
+                patch("charm.AutounsealRequirerManager", autospec=AutounsealRequirerManager)
+            ).return_value
+            self.mock_kv_manager = stack.enter_context(
+                patch("charm.KVManager", autospec=KVManager)
+            ).return_value
+            self.mock_pki_manager = stack.enter_context(
+                patch("charm.PKIManager", autospec=PKIManager)
+            ).return_value
+            self.mock_s3_requirer = stack.enter_context(
+                patch("charm.S3Requirer", autospec=S3Requirer)
+            ).return_value
+            self.mock_machine = stack.enter_context(patch("charm.Machine")).return_value
+
+            self.mock_socket_fqdn = stack.enter_context(patch("socket.getfqdn"))
+            self.mock_pki_requirer_get_assigned_certificate = stack.enter_context(
+                patch("charm.TLSCertificatesRequiresV4.get_assigned_certificate")
+            )
+            self.mock_pki_requirer_renew_certificate = stack.enter_context(
+                patch("charm.TLSCertificatesRequiresV4.renew_certificate")
+            )
+            self.mock_pki_provider_get_outstanding_certificate_requests = stack.enter_context(
+                patch("charm.TLSCertificatesProvidesV4.get_outstanding_certificate_requests")
+            )
+            self.mock_pki_provider_set_relation_certificate = stack.enter_context(
+                patch("charm.TLSCertificatesProvidesV4.set_relation_certificate")
+            )
+            self.mock_autounseal_provides_get_relations_without_credentials = stack.enter_context(
+                patch("charm.VaultAutounsealProvides.get_relations_without_credentials")
+            )
+            self.mock_autounseal_provides_set_data = stack.enter_context(
+                patch("charm.VaultAutounsealProvides.set_autounseal_data")
+            )
+            self.mock_autounseal_requires_get_details = stack.enter_context(
+                patch("charm.VaultAutounsealRequires.get_details")
+            )
+            self.mock_kv_provides_get_credentials = stack.enter_context(
+                patch("charm.VaultKvProvides.get_credentials")
+            )
+            self.mock_kv_provides_set_kv_data = stack.enter_context(
+                patch("charm.VaultKvProvides.set_kv_data")
+            )
+            self.mock_snap_cache = stack.enter_context(patch("charm.snap.SnapCache"))
+            self.mock_s3 = stack.enter_context(patch("charm.S3"))
+            yield
 
     @pytest.fixture(autouse=True)
     def context(self):

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -186,7 +186,7 @@ class TestCharmConfigure(VaultCharmFixtures):
                 "is_common_name_allowed_in_pki_role.return_value": False,
             },
         )
-        self.mock_vault_autounseal_manager.configure_mock(
+        self.mock_vault_autounseal_provider_manager.configure_mock(
             **{
                 "create_credentials.return_value": (key_name, approle_id, approle_secret_id),
             }
@@ -267,7 +267,7 @@ class TestCharmConfigure(VaultCharmFixtures):
                 "is_common_name_allowed_in_pki_role.return_value": False,
             },
         )
-        self.mock_vault_autounseal_manager.configure_mock(
+        self.mock_vault_autounseal_provider_manager.configure_mock(
             **{
                 "create_credentials.return_value": (key_name, approle_id, approle_secret_id),
             }
@@ -324,7 +324,7 @@ class TestCharmConfigure(VaultCharmFixtures):
 
         self.ctx.run(self.ctx.on.config_changed(), state_in)
 
-        self.mock_vault_autounseal_manager.create_credentials.assert_called_with(
+        self.mock_vault_autounseal_provider_manager.create_credentials.assert_called_with(
             relation,
             "https://myhostname:8200",
         )


### PR DESCRIPTION
_Note_: This could not follow the pattern used in https://github.com/canonical/vault-k8s-operator/pull/579 because Python has a limit on the number of static nesting, and the syntax there (using commas), apparently, is just syntactic sugar for multiple nesting blocks. Therefore, I had to use `ExitStack()`. I think I actually like it more, because it keeps things to one line.

context:

Patchers made more sense when we were using unittest, and we had setup and teardown methods. Now that we've moved to pytest, we can use contextmanagers by yielding within the fixture.

This ensures that the patches are properly undone after each test.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
