### PR TITLE
refactor: remove the backup code from the machine charm

### DIFF
--- a/tests/unit/fixtures.py
+++ b/tests/unit/fixtures.py
@@ -11,6 +11,7 @@ from charms.vault_k8s.v0.vault_client import VaultClient
 from charms.vault_k8s.v0.vault_managers import (
     AutounsealProviderManager,
     AutounsealRequirerManager,
+    BackupManager,
     KVManager,
     PKIManager,
     TLSManager,
@@ -45,6 +46,9 @@ class VaultCharmFixtures:
                 patch("charm.S3Requirer", autospec=S3Requirer)
             ).return_value
             self.mock_machine = stack.enter_context(patch("charm.Machine")).return_value
+            self.mock_backup_manager = stack.enter_context(
+                patch("charm.BackupManager", autospec=BackupManager)
+            ).return_value
 
             self.mock_socket_fqdn = stack.enter_context(patch("socket.getfqdn"))
             self.mock_pki_requirer_get_assigned_certificate = stack.enter_context(
@@ -75,7 +79,6 @@ class VaultCharmFixtures:
                 patch("charm.VaultKvProvides.set_kv_data")
             )
             self.mock_snap_cache = stack.enter_context(patch("charm.snap.SnapCache"))
-            self.mock_s3 = stack.enter_context(patch("charm.S3"))
             yield
 
     @pytest.fixture(autouse=True)

--- a/tests/unit/test_charm_create_backup_action.py
+++ b/tests/unit/test_charm_create_backup_action.py
@@ -5,155 +5,26 @@
 
 import ops.testing as testing
 import pytest
-from charms.vault_k8s.v0.vault_s3 import S3Error
+from charms.vault_k8s.v0.vault_managers import ManagerError
 from ops.testing import ActionFailed
 
 from tests.unit.fixtures import VaultCharmFixtures
 
 
 class TestCharmCreateBackupAction(VaultCharmFixtures):
-    def test_given_non_leader_when_create_backup_action_then_fails(self):
-        state_in = testing.State(
-            leader=False,
-        )
-        with pytest.raises(ActionFailed) as e:
-            self.ctx.run(self.ctx.on.action("create-backup"), state_in)
-
-        assert (
-            e.value.message
-            == "S3 pre-requisites not met. Only leader unit can perform backup operations."
-        )
-
-    def test_given_s3_relation_not_created_when_create_backup_action_then_fails(self):
-        state_in = testing.State(
-            leader=True,
-        )
-        with pytest.raises(ActionFailed) as e:
-            self.ctx.run(self.ctx.on.action("create-backup"), state_in)
-
-        assert e.value.message == "S3 pre-requisites not met. S3 relation not created."
-
-    def test_given_missing_s3_parameters_when_create_backup_then_action_fails(self):
-        s3_relation = testing.Relation(
-            endpoint="s3-parameters",
-            interface="s3",
-        )
-        state_in = testing.State(
-            leader=True,
-            relations=[s3_relation],
-        )
-        with pytest.raises(ActionFailed) as e:
-            self.ctx.run(self.ctx.on.action("create-backup"), state_in)
-
-        assert (
-            e.value.message
-            == "S3 pre-requisites not met. S3 parameters missing (bucket, access-key, secret-key, endpoint)."
-        )
-
-    def test_given_s3_error_when_create_backup_then_action_fails(self):
-        self.mock_s3_requirer.configure_mock(
-            **{
-                "get_s3_connection_info.return_value": {
-                    "access-key": "my-access-key",
-                    "secret-key": "my-secret-key",
-                    "endpoint": "my-endpoint",
-                    "bucket": "my bucket",
-                    "region": "my-region",
-                },
-            },
-        )
-        self.mock_s3.side_effect = S3Error()
-        s3_relation = testing.Relation(
-            endpoint="s3-parameters",
-            interface="s3",
-        )
-        state_in = testing.State(
-            leader=True,
-            relations=[s3_relation],
-        )
-        with pytest.raises(ActionFailed) as e:
-            self.ctx.run(self.ctx.on.action("create-backup"), state_in)
-
-        assert e.value.message == "Failed to create S3 session."
-
-    def test_given_bucket_creation_returns_none_when_create_backup_then_action_fails(self):
-        self.mock_s3_requirer.configure_mock(
-            **{
-                "get_s3_connection_info.return_value": {
-                    "access-key": "my-access-key",
-                    "secret-key": "my-secret-key",
-                    "endpoint": "my-endpoint",
-                    "bucket": "my bucket",
-                    "region": "my-region",
-                },
-            },
-        )
-        self.mock_s3.return_value.configure_mock(
-            **{
-                "create_bucket.return_value": None,
-            },
-        )
-        s3_relation = testing.Relation(
-            endpoint="s3-parameters",
-            interface="s3",
-        )
-        state_in = testing.State(
-            leader=True,
-            relations=[s3_relation],
-        )
-        with pytest.raises(ActionFailed) as e:
-            self.ctx.run(self.ctx.on.action("create-backup"), state_in)
-
-        assert e.value.message == "Failed to create S3 bucket."
-
     def test_given_failed_to_initialize_vault_client_when_create_backup_then_action_fails(self):
-        self.mock_s3_requirer.configure_mock(
-            **{
-                "get_s3_connection_info.return_value": {
-                    "access-key": "my-access-key",
-                    "secret-key": "my-secret-key",
-                    "endpoint": "my-endpoint",
-                    "bucket": "my bucket",
-                    "region": "my-region",
-                },
-            },
-        )
-        s3_relation = testing.Relation(
-            endpoint="s3-parameters",
-            interface="s3",
-        )
         state_in = testing.State(
             leader=True,
-            relations=[s3_relation],
+            relations=[],
         )
         with pytest.raises(ActionFailed) as e:
             self.ctx.run(self.ctx.on.action("create-backup"), state_in)
 
         assert e.value.message == "Failed to initialize Vault client."
 
-    def test_given_failed_to_upload_backup_when_create_backup_then_action_fails(self):
-        self.mock_s3_requirer.configure_mock(
-            **{
-                "get_s3_connection_info.return_value": {
-                    "access-key": "my-access-key",
-                    "secret-key": "my-secret-key",
-                    "endpoint": "my-endpoint",
-                    "bucket": "my bucket",
-                    "region": "my-region",
-                },
-            },
-        )
-        self.mock_s3.return_value.configure_mock(
-            **{
-                "upload_content.return_value": False,
-            },
-        )
-        self.mock_vault.configure_mock(
-            **{
-                "is_api_available.return_value": True,
-                "is_active_or_standby.return_value": True,
-            },
-        )
+    def test_given_manager_raises_error_when_create_backup_then_action_fails(self):
+        self.mock_backup_manager.create_backup.side_effect = ManagerError("some error message")
+
         approle_secret = testing.Secret(
             label="vault-approle-auth-details",
             tracked_content={"role-id": "role id", "secret-id": "secret id"},
@@ -170,54 +41,6 @@ class TestCharmCreateBackupAction(VaultCharmFixtures):
             relations=[s3_relation, peer_relation],
             secrets=[approle_secret],
         )
-        with pytest.raises(ActionFailed) as e:
+        with pytest.raises(testing.ActionFailed) as e:
             self.ctx.run(self.ctx.on.action("create-backup"), state_in)
-
-        assert e.value.message == "Failed to upload backup to S3 bucket."
-
-    def test_given_s3_available_when_create_backup_then_backup_created(self):
-        self.mock_s3_requirer.configure_mock(
-            **{
-                "get_s3_connection_info.return_value": {
-                    "access-key": "my-access-key",
-                    "secret-key": "my-secret-key",
-                    "endpoint": "my-endpoint",
-                    "bucket": "my bucket",
-                    "region": "my-region",
-                },
-            },
-        )
-        self.mock_s3.return_value.configure_mock(
-            **{
-                "upload_content.return_value": True,
-            },
-        )
-        self.mock_vault.configure_mock(
-            **{
-                "is_api_available.return_value": True,
-                "is_active_or_standby.return_value": True,
-            },
-        )
-        approle_secret = testing.Secret(
-            label="vault-approle-auth-details",
-            tracked_content={"role-id": "role id", "secret-id": "secret id"},
-        )
-        s3_relation = testing.Relation(
-            endpoint="s3-parameters",
-            interface="s3",
-        )
-        peer_relation = testing.PeerRelation(
-            endpoint="vault-peers",
-        )
-        state_in = testing.State(
-            leader=True,
-            relations=[s3_relation, peer_relation],
-            secrets=[approle_secret],
-        )
-        self.ctx.run(self.ctx.on.action("create-backup"), state_in)
-
-        self.mock_s3.return_value.create_bucket.assert_called_with(bucket_name="my bucket")
-        self.mock_vault.create_snapshot.assert_called()
-        self.mock_s3.return_value.upload_content.assert_called()
-        assert self.ctx.action_results
-        assert "backup-id" in self.ctx.action_results.keys()
+        assert e.value.message == "Failed to create backup: some error message"

--- a/tests/unit/test_charm_list_backups_action.py
+++ b/tests/unit/test_charm_list_backups_action.py
@@ -3,137 +3,17 @@
 # See LICENSE file for licensing details.
 
 
-import json
-
 import ops.testing as testing
 import pytest
-from charms.vault_k8s.v0.vault_s3 import S3Error
+from charms.vault_k8s.v0.vault_managers import ManagerError
 
 from tests.unit.fixtures import VaultCharmFixtures
 
 
 class TestCharmListBackupAction(VaultCharmFixtures):
-    def test_given_non_leader_when_list_backups_action_then_fails(self):
-        state_in = testing.State(
-            leader=False,
-        )
+    def test_given_manager_raises_error_when_list_backups_then_action_fails(self):
+        self.mock_backup_manager.list_backups.side_effect = ManagerError("some error message")
 
-        with pytest.raises(testing.ActionFailed) as e:
-            self.ctx.run(self.ctx.on.action("list-backups"), state_in)
-
-        assert (
-            e.value.message
-            == "S3 pre-requisites not met. Only leader unit can perform backup operations."
-        )
-
-    def test_given_s3_relation_not_created_when_list_backups_action_then_fails(self):
-        state_in = testing.State(
-            leader=True,
-        )
-
-        with pytest.raises(testing.ActionFailed) as e:
-            self.ctx.run(self.ctx.on.action("list-backups"), state_in)
-
-        assert e.value.message == "S3 pre-requisites not met. S3 relation not created."
-
-    def test_given_missing_s3_parameters_when_list_backups_then_action_fails(self):
-        s3_relation = testing.Relation(
-            endpoint="s3-parameters",
-            interface="s3",
-        )
-        state_in = testing.State(
-            leader=True,
-            relations=[s3_relation],
-        )
-
-        with pytest.raises(testing.ActionFailed) as e:
-            self.ctx.run(self.ctx.on.action("list-backups"), state_in)
-
-        assert (
-            e.value.message
-            == "S3 pre-requisites not met. S3 parameters missing (bucket, access-key, secret-key, endpoint)."
-        )
-
-    def test_given_s3_error_during_instantiation_when_list_backups_then_action_fails(self):
-        self.mock_s3_requirer.configure_mock(
-            **{
-                "get_s3_connection_info.return_value": {
-                    "access-key": "my-access-key",
-                    "secret-key": "my-secret-key",
-                    "endpoint": "my-endpoint",
-                    "bucket": "my bucket",
-                    "region": "my-region",
-                },
-            },
-        )
-        self.mock_s3.side_effect = S3Error()
-        s3_relation = testing.Relation(
-            endpoint="s3-parameters",
-            interface="s3",
-        )
-        state_in = testing.State(
-            leader=True,
-            relations=[s3_relation],
-        )
-
-        with pytest.raises(testing.ActionFailed) as e:
-            self.ctx.run(self.ctx.on.action("list-backups"), state_in)
-
-        assert e.value.message == "Failed to create S3 session."
-
-    def test_given_s3_error_during_get_object_key_when_list_backups_then_action_fails(self):
-        self.mock_s3_requirer.configure_mock(
-            **{
-                "get_s3_connection_info.return_value": {
-                    "access-key": "my-access-key",
-                    "secret-key": "my-secret-key",
-                    "endpoint": "my-endpoint",
-                    "bucket": "my bucket",
-                    "region": "my-region",
-                },
-            },
-        )
-        self.mock_s3.return_value.configure_mock(
-            **{
-                "get_object_key_list.side_effect": S3Error(),
-            },
-        )
-        s3_relation = testing.Relation(
-            endpoint="s3-parameters",
-            interface="s3",
-        )
-        state_in = testing.State(
-            leader=True,
-            relations=[s3_relation],
-        )
-
-        with pytest.raises(testing.ActionFailed) as e:
-            self.ctx.run(self.ctx.on.action("list-backups"), state_in)
-
-        assert e.value.message == "Failed to run list-backups action - Failed to list backups."
-
-    def test_given_s3_available_when_list_backups_then_backup_listed(self):
-        self.mock_s3_requirer.configure_mock(
-            **{
-                "get_s3_connection_info.return_value": {
-                    "access-key": "my-access-key",
-                    "secret-key": "my-secret-key",
-                    "endpoint": "my-endpoint",
-                    "bucket": "my bucket",
-                    "region": "my-region",
-                },
-            },
-        )
-        self.mock_s3.return_value.configure_mock(
-            **{
-                "upload_content.return_value": True,
-            },
-        )
-        self.mock_s3.return_value.configure_mock(
-            **{
-                "get_object_key_list.return_value": ["my-backup-id"],
-            },
-        )
         approle_secret = testing.Secret(
             label="vault-approle-auth-details",
             tracked_content={"role-id": "role id", "secret-id": "secret id"},
@@ -142,12 +22,14 @@ class TestCharmListBackupAction(VaultCharmFixtures):
             endpoint="s3-parameters",
             interface="s3",
         )
+        peer_relation = testing.PeerRelation(
+            endpoint="vault-peers",
+        )
         state_in = testing.State(
             leader=True,
-            relations=[s3_relation],
+            relations=[s3_relation, peer_relation],
             secrets=[approle_secret],
         )
-
-        self.ctx.run(self.ctx.on.action("list-backups"), state_in)
-
-        assert self.ctx.action_results == {"backup-ids": json.dumps(["my-backup-id"])}
+        with pytest.raises(testing.ActionFailed) as e:
+            self.ctx.run(self.ctx.on.action("list-backups"), state_in)
+        assert e.value.message == "Failed to list backups: some error message"

--- a/tests/unit/test_charm_restore_backup_action.py
+++ b/tests/unit/test_charm_restore_backup_action.py
@@ -5,164 +5,15 @@
 
 import ops.testing as testing
 import pytest
-import requests
-from charms.vault_k8s.v0.vault_client import VaultClientError
-from charms.vault_k8s.v0.vault_s3 import S3Error
-from ops.testing import ActionFailed
+from charms.vault_k8s.v0.vault_managers import ManagerError
 
 from tests.unit.fixtures import VaultCharmFixtures
 
 
 class TestCharmRestoreBackupAction(VaultCharmFixtures):
-    def test_given_non_leader_when_restore_backup_action_then_fails(self):
-        state_in = testing.State(
-            leader=False,
-        )
-        with pytest.raises(ActionFailed) as e:
-            self.ctx.run(self.ctx.on.action("restore-backup"), state_in)
+    def test_given_manager_raises_error_when_restore_backup_then_action_fails(self):
+        self.mock_backup_manager.restore_backup.side_effect = ManagerError("some error message")
 
-        assert (
-            e.value.message
-            == "S3 pre-requisites not met. Only leader unit can perform backup operations."
-        )
-
-    def test_given_s3_relation_not_created_when_restore_backup_action_then_fails(self):
-        state_in = testing.State(
-            leader=True,
-        )
-        with pytest.raises(ActionFailed) as e:
-            self.ctx.run(self.ctx.on.action("restore-backup"), state_in)
-
-        assert e.value.message == "S3 pre-requisites not met. S3 relation not created."
-
-    def test_given_missing_s3_parameters_when_restore_backup_then_action_fails(self):
-        s3_relation = testing.Relation(
-            endpoint="s3-parameters",
-            interface="s3",
-        )
-        state_in = testing.State(
-            leader=True,
-            relations=[s3_relation],
-        )
-        with pytest.raises(ActionFailed) as e:
-            self.ctx.run(self.ctx.on.action("restore-backup"), state_in)
-
-        assert (
-            e.value.message
-            == "S3 pre-requisites not met. S3 parameters missing (bucket, access-key, secret-key, endpoint)."
-        )
-
-    def test_given_s3_error_during_instantiation_when_restore_backup_then_action_fails(self):
-        self.mock_s3_requirer.configure_mock(
-            **{
-                "get_s3_connection_info.return_value": {
-                    "access-key": "my-access-key",
-                    "secret-key": "my-secret-key",
-                    "endpoint": "my-endpoint",
-                    "bucket": "my bucket",
-                    "region": "my-region",
-                },
-            },
-        )
-        self.mock_s3.side_effect = S3Error()
-
-        s3_relation = testing.Relation(
-            endpoint="s3-parameters",
-            interface="s3",
-        )
-        state_in = testing.State(
-            leader=True,
-            relations=[s3_relation],
-        )
-
-        with pytest.raises(ActionFailed) as e:
-            self.ctx.run(self.ctx.on.action("restore-backup"), state_in)
-
-        assert e.value.message == "Failed to create S3 session."
-
-    def test_given_s3_error_during_get_content_when_restore_backup_then_action_fails(self):
-        self.mock_s3_requirer.configure_mock(
-            **{
-                "get_s3_connection_info.return_value": {
-                    "access-key": "my-access-key",
-                    "secret-key": "my-secret-key",
-                    "endpoint": "my-endpoint",
-                    "bucket": "my bucket",
-                    "region": "my-region",
-                },
-            },
-        )
-        self.mock_s3.return_value.configure_mock(
-            **{
-                "get_content.side_effect": S3Error(),
-            },
-        )
-        s3_relation = testing.Relation(
-            endpoint="s3-parameters",
-            interface="s3",
-        )
-        state_in = testing.State(
-            leader=True,
-            relations=[s3_relation],
-        )
-        with pytest.raises(ActionFailed) as e:
-            self.ctx.run(self.ctx.on.action("restore-backup"), state_in)
-
-        assert e.value.message == "Failed to retrieve snapshot from S3 storage."
-
-    def test_given_no_snapshot_when_restore_backup_then_action_fails(self):
-        self.mock_s3_requirer.configure_mock(
-            **{
-                "get_s3_connection_info.return_value": {
-                    "access-key": "my-access-key",
-                    "secret-key": "my-secret-key",
-                    "endpoint": "my-endpoint",
-                    "bucket": "my bucket",
-                    "region": "my-region",
-                },
-            },
-        )
-        self.mock_s3.return_value.configure_mock(
-            **{
-                "get_content.return_value": None,
-            },
-        )
-        s3_relation = testing.Relation(
-            endpoint="s3-parameters",
-            interface="s3",
-        )
-        state_in = testing.State(
-            leader=True,
-            relations=[s3_relation],
-        )
-
-        with pytest.raises(ActionFailed) as e:
-            self.ctx.run(self.ctx.on.action("restore-backup"), state_in)
-
-        assert e.value.message == "Backup not found in S3 bucket."
-
-    def test_given_failed_to_restore_vault_when_restore_backup_then_action_fails(self):
-        self.mock_s3_requirer.configure_mock(
-            **{
-                "get_s3_connection_info.return_value": {
-                    "access-key": "my-access-key",
-                    "secret-key": "my-secret-key",
-                    "endpoint": "my-endpoint",
-                    "bucket": "my bucket",
-                    "region": "my-region",
-                },
-            },
-        )
-        self.mock_s3.return_value.configure_mock(
-            **{
-                "get_content.return_value": "my snapshot content",
-            },
-        )
-        self.mock_vault.configure_mock(
-            **{
-                "restore_snapshot.side_effect": VaultClientError(),
-            },
-        )
         approle_secret = testing.Secret(
             label="vault-approle-auth-details",
             tracked_content={"role-id": "role id", "secret-id": "secret id"},
@@ -173,62 +24,18 @@ class TestCharmRestoreBackupAction(VaultCharmFixtures):
         )
         peer_relation = testing.PeerRelation(
             endpoint="vault-peers",
+            peers_data={
+                1: {"node_api_address": "1.2.3.4"},
+            },
         )
         state_in = testing.State(
             leader=True,
             relations=[s3_relation, peer_relation],
             secrets=[approle_secret],
         )
-
-        with pytest.raises(ActionFailed) as e:
-            self.ctx.run(self.ctx.on.action("restore-backup"), state_in)
-
-        assert e.value.message == "Failed to restore vault."
-
-    def test_given_200_response_when_restore_backup_then_action_success(self):
-        self.mock_s3_requirer.configure_mock(
-            **{
-                "get_s3_connection_info.return_value": {
-                    "access-key": "my-access-key",
-                    "secret-key": "my-secret-key",
-                    "endpoint": "my-endpoint",
-                    "bucket": "my bucket",
-                    "region": "my-region",
-                },
-            },
-        )
-        self.mock_s3.return_value.configure_mock(
-            **{
-                "get_content.return_value": "my snapshot content",
-            },
-        )
-        response = requests.Response()
-        response.status_code = 200
-        self.mock_vault.configure_mock(
-            **{
-                "restore_snapshot.return_value": response,
-            },
-        )
-        approle_secret = testing.Secret(
-            label="vault-approle-auth-details",
-            tracked_content={"role-id": "role id", "secret-id": "secret id"},
-        )
-        s3_relation = testing.Relation(
-            endpoint="s3-parameters",
-            interface="s3",
-        )
-        peer_relation = testing.PeerRelation(
-            endpoint="vault-peers",
-        )
-        state_in = testing.State(
-            leader=True,
-            relations=[s3_relation, peer_relation],
-            secrets=[approle_secret],
-        )
-
-        self.ctx.run(
-            self.ctx.on.action("restore-backup", params={"backup-id": "my-backup-id"}), state_in
-        )
-
-        assert self.ctx.action_results == {"restored": "my-backup-id"}
-        self.mock_vault.restore_snapshot.assert_called_with("my snapshot content")
+        with pytest.raises(testing.ActionFailed) as e:
+            self.ctx.run(
+                self.ctx.on.action("restore-backup", params={"backup-id": "my-backup-id"}),
+                state_in,
+            )
+        assert e.value.message == "Failed to restore backup: some error message"


### PR DESCRIPTION
Removes the machine charm specific implementation of backups, and makes use of the BackupManager introduced in https://github.com/canonical/vault-k8s-operator/pull/577

~~Depends on #352~~

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
