### PR TITLE
feat: Implement bootstrap raft action

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -135,6 +135,15 @@ actions:
           stored by the charm.
     required: [secret-id] 
 
+  bootstrap-raft:
+    description: >-
+      Bootstraps raft using a peers.json file. This action requires the
+      application to first be scaled to a single unit.  Bootstrapping can help
+      recover when quorum is lost, however, it may cause uncommitted Raft log
+      entries to be committed. See
+      https://developer.hashicorp.com/vault/docs/concepts/integrated-storage#manual-recovery-using-peers-json
+      for more details.
+
   create-backup:
     description: >-
       Creates a snapshot of the Raft backend and saves it to the S3 storage.

--- a/tests/unit/fixtures.py
+++ b/tests/unit/fixtures.py
@@ -14,6 +14,7 @@ from charms.vault_k8s.v0.vault_managers import (
     BackupManager,
     KVManager,
     PKIManager,
+    RaftManager,
     TLSManager,
 )
 
@@ -48,6 +49,9 @@ class VaultCharmFixtures:
             self.mock_machine = stack.enter_context(patch("charm.Machine")).return_value
             self.mock_backup_manager = stack.enter_context(
                 patch("charm.BackupManager", autospec=BackupManager)
+            ).return_value
+            self.mock_raft_manager = stack.enter_context(
+                patch("charm.RaftManager", autospec=RaftManager)
             ).return_value
 
             self.mock_socket_fqdn = stack.enter_context(patch("socket.getfqdn"))

--- a/tests/unit/test_charm_bootstrap_raft_action.py
+++ b/tests/unit/test_charm_bootstrap_raft_action.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2024 Canonical Ltd.
+# Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 

--- a/tests/unit/test_charm_bootstrap_raft_action.py
+++ b/tests/unit/test_charm_bootstrap_raft_action.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+
+import ops.testing as testing
+import pytest
+from charms.vault_k8s.v0.vault_managers import ManagerError
+from ops.testing import ActionFailed
+
+from tests.unit.fixtures import VaultCharmFixtures
+
+
+class TestCharmBootstrapRaftAction(VaultCharmFixtures):
+    def test_given_no_network_when_bootstrap_raft_action_then_fails(self):
+        state_in = testing.State(
+            leader=True,
+        )
+
+        with pytest.raises(ActionFailed) as e:
+            self.ctx.run(self.ctx.on.action("bootstrap-raft"), state_in)
+        assert e.value.message == "Network bind address is not available"
+
+    def test_when_bootstrap_raft_raises_manager_error_then_action_fails_with_error_message(self):
+        self.mock_raft_manager.bootstrap.side_effect = ManagerError("some error message")
+        peer_relation = testing.PeerRelation(
+            endpoint="vault-peers",
+        )
+        state_in = testing.State(
+            leader=False,
+            relations=[peer_relation],
+            networks={
+                testing.Network(
+                    "vault-peers",
+                    bind_addresses=[testing.BindAddress([testing.Address("1.2.1.2")])],
+                )
+            },
+        )
+
+        with pytest.raises(ActionFailed) as e:
+            self.ctx.run(self.ctx.on.action("bootstrap-raft"), state_in)
+        assert e.value.message == "Failed to bootstrap raft: some error message"


### PR DESCRIPTION
Implements bootstrapping raft via an action as per TE133.

The user experience is as follows:

Remove all but one unit.
```
juju remove-unit vault/1 vault/2 vault/3 vault/4
```

Run the bootstrap-raft action.

```
juju run vault/leader bootstrap-raft
```

Cleanup of the `peers.json` file is done automatically by Vault once the single-unit cluster recovers.

CharmHub docs to follow in a separate task.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
