### PR TITLE
chore: add optional field to requires type relations

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -59,23 +59,28 @@ provides:
 requires:
   vault-autounseal-requires:
     interface: vault-autounseal
+    optional: true
   tls-certificates-access:
     interface: tls-certificates
     limit: 1
     description: |
       Communication between the vault units and from a client to Vault should 
       be done using the certificates provided by this integration.
+    optional: true
   tls-certificates-pki:
     interface: tls-certificates
     limit: 1
     description: |
       Interface to be used to provide Vault with its CA certificate. Vault will
       use this certificate to sign the certificates it issues on the `vault-pki` interface.
+    optional: true
   s3-parameters:
     interface: s3
+    optional: true
   ingress:
     interface: ingress
     limit: 1
+    optional: true
 
 type: charm
 bases:


### PR DESCRIPTION
# Description

We add the `optional` field next to each integration the charm requires. This fields defines if the relation is required for the charm to function. For the time being this field is informational only, i.e. Juju won't do anything with it. However, the SQA team uses this field to perform charm integration tests.

I am going through all of our charms and specifying which relation is optional and which one isn't. 

## Reference
- https://canonical-charmcraft.readthedocs-hosted.com/en/stable/reference/files/charmcraft-yaml-file/#peers-provides-and-requires

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
