### PR TITLE
build: add tiobe quality check workflow

### DIFF
--- a/.github/tics.yaml
+++ b/.github/tics.yaml
@@ -1,0 +1,23 @@
+name: TICS
+
+on:
+  workflow_dispatch: # Allows manual triggering
+  schedule:
+    - cron: "0 3 * * 0" # Runs every Sunday at 03:00 UTC
+
+jobs:
+  build:
+    runs-on: [self-hosted, linux, amd64, tiobe, jammy]
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Run TICS analysis with github-action
+        uses: tiobe/tics-github-action@88cb795a736d2ca885753bec6ed2c8b03e3f892f # v3
+        with:
+          mode: qserver
+          project: vault-operator
+          branchdir: ${{ GITHUB_WORKSPACE }}
+          viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
+          ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
+          installTics: true


### PR DESCRIPTION
This is an attempt to add the TIOBE static code analysis to the build.

There are very likely to be additional changes to this workflow, however, since it's difficult to test I'd like to get this first step merged to main, and then I can test additional changes using the workflow dispatch call.

This is based off SEC0024 and [this sample](https://github.com/canonical/ticsimg/blob/main/.github/workflows/tics_run_sh_ghaction_test.yml), with some minor tweaks:

- Use hashes to ensure workflows aren't changed from underneath us
- Set branchdir to what the docs suggested, although I'm not sure it's correct.
- Add a cron schedule to run this weekly, which was the most frequent suggested by SEC0024

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
